### PR TITLE
Updating service files

### DIFF
--- a/labguides/source/conf.py
+++ b/labguides/source/conf.py
@@ -22,6 +22,9 @@
 
 import sphinx_bootstrap_theme
 
+# Importing datetime module to auto update copyright year
+from datetime import date
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -45,8 +48,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
+# Updating copyright var to auto update with current year
 project = u'Arista ATD'
-copyright = u'2019, Arista Networks'
+copyright = u'{0}, Arista Networks'.format(date.today().year)
 author = u'Arista ATD atd-help@arista.com'
 
 # Show Source

--- a/labguides/source/connecting.rst
+++ b/labguides/source/connecting.rst
@@ -7,7 +7,7 @@ Connecting
 .. image:: images/cvp_configlet1.png
 
 2. SSH to the public IP address assigned to the LabAccess jumphost server (this is the IP address shown in the "Welcome to Arista's
-   Demo Cloud" picture above). The username is ``arista`` and the password is ``arista``:
+   Demo Cloud" picture above). The username is ``arista`` and the password is ``{REPLACE_PWD}``:
 
     .. code-block:: text
 

--- a/labvm/services/atdFiles/atdFiles.service
+++ b/labvm/services/atdFiles/atdFiles.service
@@ -6,6 +6,8 @@ Wants=network-online.target
 [Service]
 Type=forking
 ExecStart=/usr/local/bin/atdFiles.sh
+TimeoutStartSec=60
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/labvm/services/atdFiles/atdFiles.sh
+++ b/labvm/services/atdFiles/atdFiles.sh
@@ -5,10 +5,6 @@ TOPO=`cat /etc/ACCESS_INFO.yaml | shyaml get-value topology`
 
 # Clean up previous stuff to make sure it's current
 rm -rf /var/www/html/atd/labguides/
-rm -rf /home/arista/
-
-# Clone the atd-public repo
-git clone https://github.com/aristanetworks/atd-public.git /tmp/atd
 
 # Add files to arista home
 cp -R /tmp/atd/topologies/$TOPO/files/* /home/arista
@@ -25,6 +21,3 @@ mkdir /var/www/html/atd/labguides/
 # Put the new HTML and PDF in the proper directories
 mv /tmp/atd/labguides/build/latex/ATD.pdf /var/www/html/atd/labguides/
 mv /tmp/atd/labguides/build/html/* /var/www/html/atd/labguides/ && chown -R www-data:www-data /var/www/html/atd/labguides
-
-# Clean up the repo, no need to keep it
-rm -rf /tmp/atd

--- a/labvm/services/atdFiles/atdFiles.sh
+++ b/labvm/services/atdFiles/atdFiles.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 
 # Find out what topology is running
-TOPO=`cat /etc/ACCESS_INFO.yaml | shyaml get-value topology`
+TOPO=$(cat /etc/ACCESS_INFO.yaml | shyaml get-value topology)
+ARISTA_PWD=$(cat /etc/ACCESS_INFO.yaml | shyaml get-value login_info.jump_host.pw)
 
 # Clean up previous stuff to make sure it's current
 rm -rf /var/www/html/atd/labguides/
 
 # Add files to arista home
 cp -R /tmp/atd/topologies/$TOPO/files/* /home/arista
+
+# Update the Arista user password for connecting to the labvm
+sed -i "s/{REPLACE_PWD}/$ARISTA_PWD/g" /tmp/atd/labguides/source/connecting.rst
 
 # Build the lab guides html files
 cd /tmp/atd/labguides

--- a/labvm/services/atdServiceUpdater/atdServiceUpdater.py
+++ b/labvm/services/atdServiceUpdater/atdServiceUpdater.py
@@ -30,12 +30,12 @@ up_service_files = [] # Holds service file names to be restarted/started
 updater_file_name = 'atdServiceUpdater.service'
 
 # Temp path for where repo will be cloned to (include trailing /)
-GIT_TEMP_PATH = '/tmp/git-atd'
+GIT_TEMP_PATH = '/tmp/atd/'
 GIT_PATH = "https://github.com/aristanetworks/atd-public.git"
 GIT_BRANCH = "master"
 
 # Declaration for working directories
-LOCAL_GIT = "{0}/labvm/services".format(GIT_TEMP_PATH)
+LOCAL_GIT = "{0}labvm/services".format(GIT_TEMP_PATH)
 YAML_PATH = "{0}/serviceUpdater.yml".format(LOCAL_GIT)
 
 SERVICE_PATH = '/lib/systemd/system/'
@@ -307,10 +307,6 @@ def main():
         tmp_ser = SERVICES(ser)
         all_services.append(tmp_ser)
     
-    # Check if tmp directory exists, if so delete
-    if isdir(GIT_TEMP_PATH):
-        deleteLocalRepo()
-
     # Check if any files have changed and restart necessary services
     if up_service_files:
         pS("OK","Services to be Restarted: {}".format(", ".join(upser[0] for upser in up_service_files)))

--- a/labvm/services/atdServiceUpdater/atdServiceUpdater.service
+++ b/labvm/services/atdServiceUpdater/atdServiceUpdater.service
@@ -7,7 +7,6 @@ Wants=network-online.target
 Type=forking
 ExecStart=/usr/local/bin/atdServiceUpdater.py
 User=root
-TimeoutStartSec=120
 Restart=on-failure
 
 [Install]

--- a/labvm/services/gitConfigletSync/gitConfigletSync.py
+++ b/labvm/services/gitConfigletSync/gitConfigletSync.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
 from cvprac.cvp_client import CvpClient
-import git
 import os
 import time
 import shutil
@@ -19,9 +18,8 @@ except:
    topology = 'none'
    
 # Temp path for where repo will be cloned to (include trailing /)
-gitTempPath = '/tmp/GitConfiglets/'
-gitRepo = 'https://www.github.com/aristanetworks/atd-public.git'
-gitBranch = 'master'
+gitTempPath = '/tmp/atd/'
+
 # Relative path within the repo to the configlet directory
 configletPath = 'topologies/' + topology + '/configlets/'
 ignoreConfiglets = ['readme.md']
@@ -68,14 +66,14 @@ def syncConfiglet(cvpClient,configletName,configletConfig):
 
 ##### End of syncConfiglet
 
-# Download/Update the repo
-try:
+# Check if the repo has been downloaded
+while True:
    if os.path.isdir(gitTempPath):
-      shutil.rmtree(gitTempPath)
-   repo = git.Repo.clone_from(gitRepo,gitTempPath,branch=gitBranch)
-except:
-   print "There was a problem downloading the files from the repo"
-   quit()
+      print("Local copy exists....continuing")
+      break
+   else:
+      print "Local copy is missing....Waiting 1 minute for it to become available"
+      time.sleep(60)
 
 configlets = os.listdir(gitTempPath + configletPath)
 
@@ -85,5 +83,4 @@ for configletName in configlets:
          configletConfig=configletData.read()
       syncConfiglet(clnt,configletName,configletConfig)
 
-if os.path.isdir(gitTempPath):
-   shutil.rmtree(gitTempPath)
+print("Configlet sync complete")


### PR DESCRIPTION
Re-org'd the service files so the atdServiceUpdater.py file clones the atd-public repo and saves it to /tmp/atd/ directory. It will keep this directory here and not remove it. All of the other service files will reference /tmp/atd/ for any repo related information it needs.

Also fixed an issue where atdFiles.sh was removing the /home/arista directory.

