### PR TITLE
Labguide arista

### DIFF
--- a/labguides/source/programmability_connecting.rst
+++ b/labguides/source/programmability_connecting.rst
@@ -5,7 +5,7 @@ Connecting to your lab machine
 If the environment was brought up fresh and you are starting from this point, you can skip step #1.
 
 SSH to the public IP address assigned to the LabAccess jumphost server (this is the IP address shown in the
-"Welcome to Arista's Demo Cloud" picture further below). The username is ``arista`` and the password is ``arista``:
+"Welcome to Arista's Demo Cloud" picture further below). The username is ``arista`` and the password is ``{REPLACE_PWD}``:
 
     .. code-block:: text
 

--- a/labvm/services/atdFiles/atdFiles.service
+++ b/labvm/services/atdFiles/atdFiles.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 [Service]
 Type=forking
 ExecStart=/usr/local/bin/atdFiles.sh
-TimeoutStartSec=60
+TimeoutStartSec=180
 Restart=on-failure
 
 [Install]

--- a/labvm/services/atdFiles/atdFiles.sh
+++ b/labvm/services/atdFiles/atdFiles.sh
@@ -12,6 +12,7 @@ cp -R /tmp/atd/topologies/$TOPO/files/* /home/arista
 
 # Update the Arista user password for connecting to the labvm
 sed -i "s/{REPLACE_PWD}/$ARISTA_PWD/g" /tmp/atd/labguides/source/connecting.rst
+sed -i "s/{REPLACE_PWD}/$ARISTA_PWD/g" /tmp/atd/labguides/source/programmability_connecting.rst
 
 # Build the lab guides html files
 cd /tmp/atd/labguides


### PR DESCRIPTION
Found the `programmability_connecting.rst` labguide to reference the arista user to access via ssh.  Added in the `{REPLACE_PWD}` placeholder in the labguide, and added the `sed` cmd to update the password in the `atdFiles.sh` file.