### PR TITLE
Atd files patch

### DIFF
--- a/labvm/services/atdFiles/atdFiles.sh
+++ b/labvm/services/atdFiles/atdFiles.sh
@@ -13,6 +13,9 @@ cp -u /tmp/atd/topologies/all/login.py /usr/local/bin/login.py
 # Add files to arista home
 rysnc -av /tmp/atd/topologies/$TOPO/files/ /home/arista
 
+# Update file permissions in /home/arista
+chown -R arista:arista /home/arista
+
 # Update the Arista user password for connecting to the labvm
 sed -i "s/{REPLACE_PWD}/$ARISTA_PWD/g" /tmp/atd/labguides/source/connecting.rst
 sed -i "s/{REPLACE_PWD}/$ARISTA_PWD/g" /tmp/atd/labguides/source/programmability_connecting.rst

--- a/labvm/services/atdFiles/atdFiles.sh
+++ b/labvm/services/atdFiles/atdFiles.sh
@@ -11,7 +11,7 @@ rm -rf /var/www/html/atd/labguides/
 cp -u /tmp/atd/topologies/all/login.py /usr/local/bin/login.py
 
 # Add files to arista home
-rysnc -av /tmp/atd/topologies/$TOPO/files/ /home/arista
+rsync -av /tmp/atd/topologies/$TOPO/files/ /home/arista
 
 # Update file permissions in /home/arista
 chown -R arista:arista /home/arista

--- a/labvm/services/atdFiles/atdFiles.sh
+++ b/labvm/services/atdFiles/atdFiles.sh
@@ -11,7 +11,7 @@ rm -rf /var/www/html/atd/labguides/
 cp -u /tmp/atd/topologies/all/login.py /usr/local/bin/login.py
 
 # Add files to arista home
-cp -R /tmp/atd/topologies/$TOPO/files/* /home/arista
+rysnc -av /tmp/atd/topologies/$TOPO/files/ /home/arista
 
 # Update the Arista user password for connecting to the labvm
 sed -i "s/{REPLACE_PWD}/$ARISTA_PWD/g" /tmp/atd/labguides/source/connecting.rst

--- a/topologies/all/login.py
+++ b/topologies/all/login.py
@@ -78,6 +78,7 @@ Device Menu:            Lab Controls
 
       sys.stdout.write("\n")
 
+    print "   97. Screen (screen)"
     print "   98. Shell (bash)"
     print "   99. Quit (quit/exit)"
     print ""
@@ -89,6 +90,9 @@ Device Menu:            Lab Controls
       counter += 1
       if ans==str(counter) or ans==veos['hostname']:
         os.system("ssh "+veos['ip'])
+        break
+      elif ans=="97" or ans=="screen":
+        os.system('/usr/bin/screen')
         break
       elif ans=="98" or ans=="bash" or ans=="shell":
         os.system("/bin/bash")

--- a/topologies/datacenter/files/Broadcaster/pushHostMediaConfig.sh
+++ b/topologies/datacenter/files/Broadcaster/pushHostMediaConfig.sh
@@ -12,7 +12,7 @@ configure
 aaa authorization exec default local"
 
 echo "Updating File Permissions"
-sudo chown -R arista:arista /home/arista/Broadcaster/
+#sudo chown -R arista:arista /home/arista/Broadcaster/
 chmod +x /home/arista/Broadcaster/media.py
 chmod +x /home/arista/Broadcaster/configletPushToCVP.sh
 chmod +x /home/arista/Broadcaster/mcast-source.sh


### PR DESCRIPTION
Fixes #21 
Adds screen option back to the main login.py landing menu

Fixes #29 
Updated atdFiles.sh to perform an `rsync` instead of `cp`.  With `rsync` it will copy hidden files which now brings over the `.screenrc` file.