### PR TITLE
Rob login patch

### DIFF
--- a/topologies/all/login.py
+++ b/topologies/all/login.py
@@ -20,6 +20,11 @@ def sortVEOS(vd):
     tmp_l.append(tveos['hostname'])
     tmp_d[tveos['hostname']] = tveos
   tmp_l.sort(key=natural_keys)
+  # If cvx in list, move to end
+  if 'cvx' in tmp_l[0]:
+        tmp_cvx = tmp_l[0]
+        tmp_l.pop(0)
+        tmp_l.append(tmp_cvx)
   for tveos in tmp_l:
     fin_l.append(tmp_d[tveos])
   return(fin_l)
@@ -46,14 +51,6 @@ login = accessinfo['login_info']
 nodes = accessinfo['nodes']
 tag = accessinfo['tag']
 
-labcontrols = menuoptions['options']
-# Check to see if this is the datacenter topo
-if topology == 'datacenter':
-  labcontrols2 = menuoptions['media-options']
-else:
-  # If topo other than datacenter, set to False
-  labcontrols2 = False
-
 cvplogin = login['cvp']
 veoslogin = login['veos'][0]
 
@@ -68,8 +65,16 @@ cvpinfo = nodes['cvp'][0]
 cvp = cvpinfo['ip']
 
 veosinfo = nodes['veos']
-# Sort the list naturally
-veosinfo = sortVEOS(veosinfo)
+
+labcontrols = menuoptions['options']
+# Check to see if this is the datacenter topo
+if topology == 'datacenter':
+  labcontrols2 = menuoptions['media-options']
+else:
+  # If topo other than datacenter, set to False
+  labcontrols2 = False
+  # Sort the list naturally
+  veosinfo = sortVEOS(veosinfo)
 
 if sys.stdout.isatty():
 

--- a/topologies/all/login.py
+++ b/topologies/all/login.py
@@ -2,8 +2,27 @@
 import os
 import sys
 import signal
+import re
 from ruamel.yaml import YAML
 from itertools import izip_longest
+
+def atoi(text):
+  return int(text) if text.isdigit() else text
+
+def natural_keys(text):
+  return [ atoi(c) for c in re.split(r'(\d+)', text) ]
+  
+def sortVEOS(vd):
+  tmp_l = []
+  tmp_d = {}
+  fin_l = []
+  for tveos in vd:
+    tmp_l.append(tveos['hostname'])
+    tmp_d[tveos['hostname']] = tveos
+  tmp_l.sort(key=natural_keys)
+  for tveos in tmp_l:
+    fin_l.append(tmp_d[tveos])
+  return(fin_l)
 
 f = open('/etc/ACCESS_INFO.yaml')
 accessinfo = YAML().load(f)
@@ -12,9 +31,6 @@ f.close()
 f = open('/home/arista/MenuOptions.yaml')
 menuoptions = YAML().load(f)
 f.close()
-
-labcontrols = menuoptions['options']
-labcontrols2 = menuoptions['media-options']
 
 # Check to see if we need the media menu
 enableControls2 = False
@@ -30,6 +46,14 @@ login = accessinfo['login_info']
 nodes = accessinfo['nodes']
 tag = accessinfo['tag']
 
+labcontrols = menuoptions['options']
+# Check to see if this is the datacenter topo
+if topology == 'datacenter':
+  labcontrols2 = menuoptions['media-options']
+else:
+  # If topo other than datacenter, set to False
+  labcontrols2 = False
+
 cvplogin = login['cvp']
 veoslogin = login['veos'][0]
 
@@ -44,6 +68,8 @@ cvpinfo = nodes['cvp'][0]
 cvp = cvpinfo['ip']
 
 veosinfo = nodes['veos']
+# Sort the list naturally
+veosinfo = sortVEOS(veosinfo)
 
 if sys.stdout.isatty():
 


### PR DESCRIPTION
Fixes #40
This corrects an issue where `login.py` would crash when trying to load on the routing topology.
This also sorts the routing topology device list based off alphanumeric on device name.