### PR TITLE
Cfg aws update

### DIFF
--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -13,7 +13,7 @@ DEBUG = False
 def remove_configlets(client, device):
     # Removes all configlets except the ones defined here or starting with SYS_
     # Define base configlets that are to be untouched
-    base_configlets = ['AAA']
+    base_configlets = ['AAA','aws-infa']
     
     configlets_to_remove = []
 

--- a/topologies/datacenter/configlets/aws-infra
+++ b/topologies/datacenter/configlets/aws-infra
@@ -1,0 +1,1 @@
+agent PhyEthtool shutdown

--- a/topologies/routing/configlets/aws-infra
+++ b/topologies/routing/configlets/aws-infra
@@ -1,0 +1,1 @@
+agent PhyEthtool shutdown

--- a/topologies/routing/files/cvp/cvp_info.yaml
+++ b/topologies/routing/files/cvp/cvp_info.yaml
@@ -34,6 +34,7 @@ cvp_info:
     containers:
       Tenant:
         - AAA
+        - aws-infa
     netelements:
       eos1:
         - BaseIPv4_EOS1


### PR DESCRIPTION
Creating the `aws-infa` configlet to be applied to the ATDs.  According to @dathelen this cmd will prevent the logs from filling up due to the PhyEthtool agent crashing. 

> PhyEthTool repeatedly crashes on veos running in AWS