### PR TITLE
Adding BaseIPv4 to standard routing configlet

### DIFF
--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -20,7 +20,7 @@ def remove_configlets(client, device):
     device_id = device['systemMacAddress']
     configlets = client.api.get_configlets_by_device_id(device_id)
     for configlet in configlets:
-        if configlet['name'] in base_configlets or configlet['name'].startswith('SYS_'):
+        if configlet['name'] in base_configlets or configlet['name'].startswith('SYS_') or configlet['name'].startswith('BaseIPv4_'):
             continue
         else:
             if DEBUG:


### PR DESCRIPTION
In the routing topology, when a lab control option is pushed, the device loses it's mgmt IP address since the `BaseIPv4_` configlet is removed.  In doing so makes the device inaccessible.

This PR adds `BaseIPv4_` configlets as a standard configlet to remain.