### PR TITLE
requiring cvpUpdater to complete before config sync

### DIFF
--- a/labvm/services/gitConfigletSync/gitConfigletSync.service
+++ b/labvm/services/gitConfigletSync/gitConfigletSync.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Automatically updates configlets
-Required=atdServiceUpdater.service
-After=atdServiceUpdater.service
+Required=cvpUpdater.service
+After=cvpUpdater.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
Fixes #79 
In the Routing topology it leverages a cvpUpdater.py to configure and provision a blank CVP for use in the topology.  During initial configuration there is a race between cvpUpdater.py and gitConfigletSync.py and causes an issue with certain configlets from being updated in the future.

This change moves gitConfigletSync.py to be started once cvpUpdater.py has completed running on boot.