### PR TITLE
Patch host cfgs

### DIFF
--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -15,7 +15,7 @@ def remove_configlets(client, device, mext=None):
     Define base configlets that are to be untouched
     mext = lab type to keep track of which base configlets to keep.  Added for RATD and RATD-Ring
     """
-    base_configlets = ['AAA','aws-infra','ATD-INFRA']
+    base_configlets = ['AAA','aws-infra','ATD-INFRA', 'VLANs']
     
     configlets_to_remove = []
     configlets_to_remain = []

--- a/topologies/datacenter-latest/configlets/Host1-ATD
+++ b/topologies/datacenter-latest/configlets/Host1-ATD
@@ -1,0 +1,24 @@
+interface Port-Channel1
+   no switchport
+   ip address 172.16.112.201/24
+!
+interface Port-Channel2
+   no switchport
+   ip address 172.16.115.100/24
+!
+interface Ethernet1
+   channel-group 1 mode active
+   lacp rate fast
+!
+interface Ethernet2
+   channel-group 1 mode active
+   lacp rate fast
+!
+interface Ethernet3
+   channel-group 2 mode active
+   lacp rate fast
+!
+interface Ethernet4
+   channel-group 2 mode active
+   lacp rate fast
+!

--- a/topologies/datacenter-latest/configlets/Host1-ATD
+++ b/topologies/datacenter-latest/configlets/Host1-ATD
@@ -22,6 +22,5 @@ interface Ethernet4
    channel-group 2 mode active
    lacp timer fast
 !
-!!ip route 0.0.0.0/0 172.16.115.1
 ip route 172.16.134.0/24 172.16.112.1
 !

--- a/topologies/datacenter-latest/configlets/Host1-ATD
+++ b/topologies/datacenter-latest/configlets/Host1-ATD
@@ -8,19 +8,19 @@ interface Port-Channel2
 !
 interface Ethernet1
    channel-group 1 mode active
-   lacp rate fast
+   lacp timer fast
 !
 interface Ethernet2
    channel-group 1 mode active
-   lacp rate fast
+   lacp timer fast
 !
 interface Ethernet3
    channel-group 2 mode active
-   lacp rate fast
+   lacp timer fast
 !
 interface Ethernet4
    channel-group 2 mode active
-   lacp rate fast
+   lacp timer fast
 !
 ip route 0.0.0.0/0 172.16.115.1
 ip route 172.16.134.0/24 172.16.112.1

--- a/topologies/datacenter-latest/configlets/Host1-ATD
+++ b/topologies/datacenter-latest/configlets/Host1-ATD
@@ -22,6 +22,6 @@ interface Ethernet4
    channel-group 2 mode active
    lacp timer fast
 !
-ip route 0.0.0.0/0 172.16.115.1
+!!ip route 0.0.0.0/0 172.16.115.1
 ip route 172.16.134.0/24 172.16.112.1
 !

--- a/topologies/datacenter-latest/configlets/Host1-ATD
+++ b/topologies/datacenter-latest/configlets/Host1-ATD
@@ -22,3 +22,6 @@ interface Ethernet4
    channel-group 2 mode active
    lacp rate fast
 !
+ip route 0.0.0.0/0 172.16.115.1
+ip route 172.16.134.0/24 172.16.112.1
+!

--- a/topologies/datacenter-latest/configlets/Host1-Media
+++ b/topologies/datacenter-latest/configlets/Host1-Media
@@ -1,0 +1,17 @@
+interface Ethernet1
+   no switchport
+   ip address 172.16.15.5/24
+!
+interface Ethernet2
+   shutdown
+!
+interface Ethernet3
+   shutdown
+!
+interface Ethernet4
+   shutdown
+!
+ip route 0.0.0.0/0 172.16.15.1
+ip route 10.127.0.0/16 172.16.15.1
+ip route 172.16.0.0/16 172.16.15.1
+!

--- a/topologies/datacenter-latest/configlets/Host2-ATD
+++ b/topologies/datacenter-latest/configlets/Host2-ATD
@@ -19,6 +19,6 @@ interface Ethernet4
    channel-group 2 mode active
 !
 !
-ip route 0.0.0.0/0 172.16.116.1
+!!ip route 0.0.0.0/0 172.16.116.1
 ip route 172.16.112.0/24 172.16.134.1
 !

--- a/topologies/datacenter-latest/configlets/Host2-ATD
+++ b/topologies/datacenter-latest/configlets/Host2-ATD
@@ -18,3 +18,7 @@ interface Ethernet3
 interface Ethernet4
    channel-group 2 mode active
 !
+!
+ip route 0.0.0.0/0 172.16.116.1
+ip route 172.16.112.0/24 172.16.134.1
+!

--- a/topologies/datacenter-latest/configlets/Host2-ATD
+++ b/topologies/datacenter-latest/configlets/Host2-ATD
@@ -1,0 +1,20 @@
+interface Port-Channel1
+   no switchport
+   ip address 172.16.112.202/24
+!
+interface Port-Channel2
+   no switchport
+   ip address 172.16.116.100/24
+!
+interface Ethernet1
+   channel-group 1 mode active
+!
+interface Ethernet2
+   channel-group 1 mode active
+!
+interface Ethernet3
+   channel-group 2 mode active
+!
+interface Ethernet4
+   channel-group 2 mode active
+!

--- a/topologies/datacenter-latest/configlets/Host2-ATD
+++ b/topologies/datacenter-latest/configlets/Host2-ATD
@@ -19,6 +19,5 @@ interface Ethernet4
    channel-group 2 mode active
 !
 !
-!!ip route 0.0.0.0/0 172.16.116.1
 ip route 172.16.112.0/24 172.16.134.1
 !

--- a/topologies/datacenter-latest/configlets/Host2-Media
+++ b/topologies/datacenter-latest/configlets/Host2-Media
@@ -1,0 +1,21 @@
+interface Ethernet1
+   shutdown
+!
+interface Ethernet2
+   no switchport
+   ip address 172.16.46.6/24
+!
+!
+interface Ethernet3
+   shutdown
+!
+interface Ethernet4
+   shutdown
+!
+ip route 0.0.0.0/0 172.16.46.4
+ip route 10.127.0.0/16 172.16.46.4
+ip route 172.16.0.0/16 172.16.46.4
+!
+ip routing
+!
+ip multicast-routing

--- a/topologies/datacenter-latest/files/MenuOptions.yaml
+++ b/topologies/datacenter-latest/files/MenuOptions.yaml
@@ -62,6 +62,8 @@ labconfiglets:
       - "VLANs"
     leaf4:
       - "VLANs"
+    cvx01:
+      - "cvx01-Controller"
     host1:
       - "Host1-ATD"
     host2:
@@ -79,6 +81,8 @@ labconfiglets:
       - "Leaf3-BGP-Lab"
     leaf4:
       - "Leaf4-BGP-Lab"
+    cvx01:
+      - "cvx01-Controller"
     host1:
       - "Host1-ATD"
     host2:
@@ -100,6 +104,8 @@ labconfiglets:
     leaf4:
       - "Leaf4-VXLAN-Lab"
       - "VLANs"
+    cvx01:
+      - "cvx01-Controller"
     host1:
       - "Host1-ATD"
     host2:
@@ -120,6 +126,8 @@ labconfiglets:
     leaf4:
       - "Leaf4-L2EVPN-Lab"
       - "VLANs"
+    cvx01:
+      - "cvx01-Controller"
     host1:
       - "Host1-ATD"
     host2:
@@ -135,6 +143,8 @@ labconfiglets:
       - "Leaf2-L3EVPN-Lab"
     leaf4:
       - "Leaf4-L3EVPN-Lab"
+    cvx01:
+      - "cvx01-Controller"
     host1:
       - "Host1-ATD"
     host2:
@@ -152,6 +162,8 @@ labconfiglets:
       - "Leaf3-BGP-Lab"
     leaf4:
       - "Leaf4-BGP-Lab-Full"
+    cvx01:
+      - "cvx01-Controller"
     host1:
       - "Host1-ATD"
     host2:

--- a/topologies/datacenter-latest/files/MenuOptions.yaml
+++ b/topologies/datacenter-latest/files/MenuOptions.yaml
@@ -62,6 +62,10 @@ labconfiglets:
       - "VLANs"
     leaf4:
       - "VLANs"
+    host1:
+      - "Host1-ATD"
+    host2:
+      - "Host2-ATD"
   bgp:
     spine1:
       - "Spine1-BGP-Lab"
@@ -75,6 +79,10 @@ labconfiglets:
       - "Leaf3-BGP-Lab"
     leaf4:
       - "Leaf4-BGP-Lab"
+    host1:
+      - "Host1-ATD"
+    host2:
+      - "Host2-ATD"
   vxlan:
     spine1:
       - "Spine1-BGP-Lab"
@@ -92,6 +100,10 @@ labconfiglets:
     leaf4:
       - "Leaf4-VXLAN-Lab"
       - "VLANs"
+    host1:
+      - "Host1-ATD"
+    host2:
+      - "Host2-ATD"
   l2evpn:
     spine1:
       - "Spine1-L2EVPN-Lab"
@@ -108,6 +120,10 @@ labconfiglets:
     leaf4:
       - "Leaf4-L2EVPN-Lab"
       - "VLANs"
+    host1:
+      - "Host1-ATD"
+    host2:
+      - "Host2-ATD"
   l3evpn:
     spine1:
       - "Spine1-L3EVPN-Lab"
@@ -119,6 +135,10 @@ labconfiglets:
       - "Leaf2-L3EVPN-Lab"
     leaf4:
       - "Leaf4-L3EVPN-Lab"
+    host1:
+      - "Host1-ATD"
+    host2:
+      - "Host2-ATD"
   cvp:
     spine1:
       - "Spine1-BGP-Lab"
@@ -132,6 +152,10 @@ labconfiglets:
       - "Leaf3-BGP-Lab"
     leaf4:
       - "Leaf4-BGP-Lab-Full"
+    host1:
+      - "Host1-ATD"
+    host2:
+      - "Host2-ATD"
   media-intro:
     spine1:
       - "media-spine1-IP-Intro-start"
@@ -145,6 +169,10 @@ labconfiglets:
       - "media-leaf3-IP-Intro-start"
     leaf4:
       - "media-leaf4-IP-Intro-start"
+    host1:
+      - "Host1-Media"
+    host2:
+      - "Host2-Media"
   media-vlan:
     spine1:
       - "media-spine1-VLAN-STP-start"
@@ -158,6 +186,10 @@ labconfiglets:
       - "media-leaf3-VLAN-STP-start"
     leaf4:
       - "media-leaf4-VLAN-STP-start"
+    host1:
+      - "Host1-Media"
+    host2:
+      - "Host2-Media"
   media-ospf:
     spine1:
       - "media-spine1-OSPF-start"
@@ -171,6 +203,10 @@ labconfiglets:
       - "media-leaf3-OSPF-start"
     leaf4:
       - "media-leaf4-OSPF-start"
+    host1:
+      - "Host1-Media"
+    host2:
+      - "Host2-Media"
   media-bgp:
     spine1:
       - "media-spine1-BGP-start"
@@ -184,6 +220,10 @@ labconfiglets:
       - "media-leaf3-BGP-start"
     leaf4:
       - "media-leaf4-BGP-start"
+    host1:
+      - "Host1-Media"
+    host2:
+      - "Host2-Media"
   media-mcast:
     spine1:
       - "media-spine1-Multicast-lab"
@@ -197,3 +237,7 @@ labconfiglets:
       - "media-leaf3-Multicast-lab"
     leaf4:
       - "media-leaf4-Multicast-lab"
+    host1:
+      - "Host1-Media"
+    host2:
+      - "Host2-Media"

--- a/topologies/datacenter-latest/files/cvp/cvp_info.yaml
+++ b/topologies/datacenter-latest/files/cvp/cvp_info.yaml
@@ -43,8 +43,10 @@ cvp_info:
         - BaseIPv4_Leaf4
       host1:
         - BaseIPv4_Host1
+        - Host1-ATD
       host2:
         - BaseIPv4_Host2
+        - Host2-ATD
       cvx01:
         - BaseIPv4_Cvx01
         - cvx01-Controller


### PR DESCRIPTION
Fixes #95 
Fixed an issue where the host devices in the `datacenter-latest` topo were missing interface level configurations.  Added the configlets for those devices and added the proper mappings for those nodes.

Also added the 'VLANs' configlet used in the `datacenter-latest` topo to a base configlet in `ConfigureTopology.py`