### PR TITLE
bumping dc latest veos to 4.22.2f

### DIFF
--- a/topologies/datacenter-latest/Datacenter.yml
+++ b/topologies/datacenter-latest/Datacenter.yml
@@ -1,6 +1,6 @@
 cloud_service: aws:adc
 default_interfaces: 8
-default_ami_name: 4.22.2.1F
+default_ami_name: 4.22.2F
 cvp_instance: singlenode
 cvp_version: 2019.1.1
 topology_name: datacenter-latest


### PR DESCRIPTION
There is either an issue with the AMI, or vEOS node when the topology reboots.  Downgrading the vEOS version for testing purposes.