### PR TITLE
downgrading dc latest veos to 4.21.7m

### DIFF
--- a/topologies/datacenter-latest/Datacenter.yml
+++ b/topologies/datacenter-latest/Datacenter.yml
@@ -1,6 +1,6 @@
 cloud_service: aws:adc
 default_interfaces: 8
-default_ami_name: 4.22.0F
+default_ami_name: 4.21.7M
 cvp_instance: singlenode
 cvp_version: 2019.1.1
 topology_name: datacenter-latest


### PR DESCRIPTION
Downgrading to 4.21.7M, supposed working release.