### PR TITLE
reverting dc latest veos version to 4.22.2.1F

### DIFF
--- a/topologies/datacenter-latest/Datacenter.yml
+++ b/topologies/datacenter-latest/Datacenter.yml
@@ -1,6 +1,6 @@
 cloud_service: aws:adc
 default_interfaces: 8
-default_ami_name: 4.21.7M
+default_ami_name: 4.22.2.1F
 cvp_instance: singlenode
 cvp_version: 2019.1.1
 topology_name: datacenter-latest


### PR DESCRIPTION
Reverting the datacenter-latest topo back to 4.22.2.1F.