### PR TITLE
setting ratd veos to 4.21.2F

### DIFF
--- a/topologies/routing/Routing.yml
+++ b/topologies/routing/Routing.yml
@@ -1,6 +1,6 @@
 cloud_service: aws:adc
 default_interfaces: 8
-default_ami_name: 4.22.2.1F
+default_ami_name: 4.21.2F
 cvp_instance: singlenode
 cvp_version: 2019.1.1
 topology_name: routing


### PR DESCRIPTION
Changing the vEOS version for the routing topology to a "known" working version.