### PR TITLE
Atd infra update

### DIFF
--- a/topologies/datacenter-latest/configlets/ATD-INFRA
+++ b/topologies/datacenter-latest/configlets/ATD-INFRA
@@ -18,3 +18,14 @@ tacacs-server host 192.168.0.4
 management api http-commands
    no shutdown
 !
+event-handler iptables-vxlan
+   trigger on-boot
+   action bash sudo iptables -I INPUT 1 -p udp --dport 4789 -j ACCEPT
+   asynchronous
+!
+event-handler ovs-restart
+   trigger on-boot
+   action bash sudo systemctl restart openvswitch
+   delay 30
+   asynchronous
+!

--- a/topologies/datacenter-latest/configlets/ATD-INFRA
+++ b/topologies/datacenter-latest/configlets/ATD-INFRA
@@ -1,5 +1,3 @@
-agent PhyEthtool shutdown
-!
 daemon TerminAttr
   exec /usr/bin/TerminAttr -ingestgrpcurl=192.168.0.5:9910 -taillogs -ingestauth=key,1a38fe7df56879d685e51b6f0ff86327 -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
   no shutdown

--- a/topologies/routing/configlets/ATD-INFRA
+++ b/topologies/routing/configlets/ATD-INFRA
@@ -16,3 +16,14 @@ username arista sshkey ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6bJB3TkBEQZ9jNyO1k
 tacacs-server key 7 070E33455D1D18
 tacacs-server host 192.168.0.4
 !
+event-handler iptables-vxlan
+   trigger on-boot
+   action bash sudo iptables -I INPUT 1 -p udp --dport 4789 -j ACCEPT
+   asynchronous
+!
+event-handler ovs-restart
+   trigger on-boot
+   action bash sudo systemctl restart openvswitch
+   delay 30
+   asynchronous
+!

--- a/topologies/routing/configlets/ATD-INFRA
+++ b/topologies/routing/configlets/ATD-INFRA
@@ -1,5 +1,3 @@
-agent PhyEthtool shutdown
-!
 daemon TerminAttr
   exec /usr/bin/TerminAttr -ingestgrpcurl=192.168.0.5:9910 -taillogs -ingestauth=key,1a38fe7df56879d685e51b6f0ff86327 -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
   no shutdown


### PR DESCRIPTION
Adding in missing event-handlers that EOS+ configures on vEOS nodes.  This is the cause for the nodes not coming up after a topo spin down/up or reboot.  Also `agent PhyEthtool shutdown` is no longer needed in 4.23.1F.