### PR TITLE
Dclatest eos patch

### DIFF
--- a/topologies/datacenter-latest/files/veos-patch.sh
+++ b/topologies/datacenter-latest/files/veos-patch.sh
@@ -16,6 +16,7 @@ do
 scp KernelVersion-patch-bug431736.i686.rpm arista@$i:/mnt/flash/
 ssh arista@$i copy flash:/KernelVersion-patch-bug431736.i686.rpm extension:/
 ssh arista@$i extension KernelVersion-patch-bug431736.i686.rpm
+ssh arista@$i copy installed-extensions boot-extensions
 done
 cd /home/arista
 rm -rf /home/arista/patch

--- a/topologies/datacenter-latest/files/veos-patch.sh
+++ b/topologies/datacenter-latest/files/veos-patch.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo 'Gatering necessary files.'
+mkdir /home/arista/patch
+git clone git@github.com:/aristanetworks/atd.git /home/arista/patch/
+
+cd /home/arista/patch
+
+git checkout -b veos-patch origin/veos-patch
+
+cd patches/4.23.0.1F
+
+echo "Adding patch file spine and leaf nodes.."
+for i in 192.168.0.10 192.168.0.11 192.168.0.14 192.168.0.15 192.168.0.16 192.168.0.17
+do
+scp KernelVersion-patch-bug431736.i686.rpm arista@$i:/mnt/flash/
+ssh arista@$i copy flash:/KernelVersion-patch-bug431736.i686.rpm extension:/
+ssh arista@$i extension KernelVersion-patch-bug431736.i686.rpm
+done
+echo "Done!"

--- a/topologies/datacenter-latest/files/veos-patch.sh
+++ b/topologies/datacenter-latest/files/veos-patch.sh
@@ -17,4 +17,6 @@ scp KernelVersion-patch-bug431736.i686.rpm arista@$i:/mnt/flash/
 ssh arista@$i copy flash:/KernelVersion-patch-bug431736.i686.rpm extension:/
 ssh arista@$i extension KernelVersion-patch-bug431736.i686.rpm
 done
+cd /home/arista
+rm -rf /home/arista/patch
 echo "Done!"

--- a/topologies/datacenter-latest/labguides/source/l2evpn.rst
+++ b/topologies/datacenter-latest/labguides/source/l2evpn.rst
@@ -154,6 +154,9 @@ L2 EVPN
 
             enable
             ping 172.16.112.202
+        
+        .. note:: If the pings are failing, try selecting option **98** or type in **bash** 
+                  from the login menu, then type **./veos-patch.sh**          
 
    3. On **leaf1** and **leaf3**
 

--- a/topologies/datacenter-latest/labguides/source/l3evpn.rst
+++ b/topologies/datacenter-latest/labguides/source/l3evpn.rst
@@ -169,6 +169,9 @@ L3 EVPN
 
             enable
             ping 172.16.116.100
+        
+        .. note:: If the pings are failing, try selecting option **98** or type in **bash** 
+                  from the login menu, then type **./veos-patch.sh**  
 
    3. On **leaf1** and **leaf3**
 


### PR DESCRIPTION
This is a temporary fix to install a Kernel patch on the vEOS nodes to prevent the EvpnrtrEncapAgent from crashing.  This script will allow the L2EVPN and L3EVPN labs to be completed successfully.