### PR TITLE
Patch conf topo reset

### DIFF
--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -82,10 +82,8 @@ def update_topology(client, lab, configlets):
           # Apply the configlets to the device
           client.addDeviceConfiglets(device, lab_configlets)
           client.applyConfiglets(device)
-          client.saveTopology()
-        # Adding check for reset option to apply configlets as necessary
-        elif lab == 'reset':
-          client.saveTopology()
+    # Perform a single Save Topology by default
+    client.saveTopology()
 
     return
 

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -26,9 +26,13 @@ def remove_configlets(client, device, mext=None):
             # Do further evaluation on RATD topo to distinguish between standard RATD and RATD-Ring modules
             if configlet['name'].startswith('BaseIPv4_'):
                 if mext and '_RING' not in configlet['name']:
-                    configlets_to_remove.append( {'name': configlet['name'], 'key': configlet['key']} )
+                    configlets_to_remove.append(configlet['name'])
                 elif not mext and '_RING' in configlet['name']:
-                    configlets_to_remove.append( {'name': configlet['name'], 'key': configlet['key']} )
+                    configlets_to_remove.append(configlet['name'])
+                else:
+                    configlets_to_remain.append(configlet['name'])
+            else:
+                configlets_to_remain.append(configlet['name'])
             continue
         else:
             pS("INFO", "Configlet {0} not part of base on {1} - Removing from device".format(configlet['name'], device.hostname))

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -79,6 +79,10 @@ def update_topology(client, lab, configlets):
           client.addDeviceConfiglets(device, lab_configlets)
           client.applyConfiglets(device)
           client.saveTopology()
+        # Adding check for reset option to apply configlets as necessary
+        elif lab == 'reset':
+          client.applyConfiglets(device)
+          client.saveTopology()
 
     return
 

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -85,7 +85,6 @@ def update_topology(client, lab, configlets):
           client.saveTopology()
         # Adding check for reset option to apply configlets as necessary
         elif lab == 'reset':
-          client.applyConfiglets(device)
           client.saveTopology()
 
     return


### PR DESCRIPTION
Fixes #117 

Fixes an issue when the devices weren't getting the base configlets pushed to them via CVP.  To test out on topologies run the following in bash on the jumphost:
```
cd /tmp/atd
sudo su
git checkout topologies
git checkout -b patch-confTopo-reset origin/patch-confTopo-reset
bash labvm/services/atdFiles/atdFiles.sh
exit
exit
```