### PR TITLE
fixed service script requirements field and disabling timeouts

### DIFF
--- a/labvm/services/atdFiles/atdFiles.service
+++ b/labvm/services/atdFiles/atdFiles.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=Automatically downloads updated ATD files and documentation
-Required=atdServiceUpdater.service
+Requires=atdServiceUpdater.service
 After=atdServiceUpdater.service
 
 [Service]
 Type=forking
 ExecStart=/usr/local/bin/atdFiles.sh
-TimeoutStartSec=180
+TimeoutStartSec=infinity
 Restart=on-failure
 RestartSec=60
 

--- a/labvm/services/atdServiceUpdater/atdServiceUpdater.service
+++ b/labvm/services/atdServiceUpdater/atdServiceUpdater.service
@@ -6,6 +6,7 @@ Wants=network-online.target
 [Service]
 Type=forking
 ExecStart=/usr/local/bin/atdServiceUpdater.py
+TimeoutStartSec=infinity
 User=root
 Restart=on-failure
 

--- a/labvm/services/cvpUpdater/cvpUpdater.service
+++ b/labvm/services/cvpUpdater/cvpUpdater.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=Automatically configures CVP with EOS devices depending on the topology
-Required=atdFiles.service
+Requires=atdFiles.service
 After=atdFiles.service
 
 [Service]
 Type=forking
 ExecStart=/usr/local/bin/cvpUpdater.py
 User=arista
-TimeoutStartSec=900
+TimeoutStartSec=infinity
 Restart=on-failure
 RestartSec=60
 

--- a/labvm/services/gitConfigletSync/gitConfigletSync.service
+++ b/labvm/services/gitConfigletSync/gitConfigletSync.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=Automatically updates configlets
-Required=cvpUpdater.service
+Requires=cvpUpdater.service
 After=cvpUpdater.service
 
 [Service]
 Type=forking
 ExecStart=/usr/local/bin/gitConfigletSync.py
 User=arista
-TimeoutStartSec=180
+TimeoutStartSec=infinity
 Restart=on-failure
 RestartSec=60
 

--- a/labvm/services/sslUpdater/sslUpdater.service
+++ b/labvm/services/sslUpdater/sslUpdater.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=Automatically updates the CVP self-signed cert
-Required=atdFiles.service
+Requires=atdFiles.service
 After=atdFiles.service
 
 [Service]
 Type=forking
 ExecStart=/usr/local/bin/sslUpdater.py
-TimeoutStartSec=180
+TimeoutStartSec=infinity
 Restart=on-failure
 RestartSec=60
 


### PR DESCRIPTION
Fixes an issue where service scripts are not waiting for previous script to complete.  Also sets no timeout for the scripts to complete.  There is a condition when they restart that the original script is still running and multiple processes of the same script are running.  Could cause issues with configuring devices like CVP.