### PR TITLE
Fix multicast lab issue145

### DIFF
--- a/topologies/datacenter-latest/files/Broadcaster/mcast-receiver.sh
+++ b/topologies/datacenter-latest/files/Broadcaster/mcast-receiver.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
+echo "Starting Receivers"
+sudo ip route add 239.103.1.1/32 dev et2
+sudo ip route add 239.103.1.2/32 dev et2
+sudo ip route add 239.103.1.3/32 dev et2
 iperf -s -u -B 239.103.1.1 -i 1 &
 iperf -s -u -B 239.103.1.2 -i 1 &

--- a/topologies/datacenter-latest/files/Broadcaster/mcast-source.sh
+++ b/topologies/datacenter-latest/files/Broadcaster/mcast-source.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-#echo Starting source 239.103,1,1-3 for 1800 seconds
+#echo Starting source 239.103.1.1-3 for 1800 seconds
+echo "Starting Sources"
+#adding routes in kernel to prefer et1 instead of ATD underlay interface
+sudo ip route add 239.103.1.1/32 dev et1
+sudo ip route add 239.103.1.2/32 dev et1
+sudo ip route add 239.103.1.3/32 dev et1
 
 for i in {1..3} ; do
     IP='239.103.1'


### PR DESCRIPTION
added static route mapping lines to multicast source and receiver scripts for the media-mcast lab to function correctly.  Tested manually switching branches and the script works correctly for the lab and the lab functions as expected.