### PR TITLE
beta-dc testing green eft6

### DIFF
--- a/topologies/beta-datacenter/topo_build.yml
+++ b/topologies/beta-datacenter/topo_build.yml
@@ -2,7 +2,8 @@ cloud_service: aws:adc
 default_interfaces: 8
 default_ami_name: 4.24.0F
 cvp_instance: singlenode
-cvp_version: 2020.1.0-EFT6
+cvp_version: 2020.1.0-RC1
+
 topology_name: beta-datacenter
 external_configuration: true
 only_add_to_inventory: false

--- a/topologies/beta-datacenter/topo_build.yml
+++ b/topologies/beta-datacenter/topo_build.yml
@@ -2,7 +2,7 @@ cloud_service: aws:adc
 default_interfaces: 8
 default_ami_name: 4.24.0F
 cvp_instance: singlenode
-cvp_version: 2019.1.4
+cvp_version: 2020.1.0-EFT6
 topology_name: beta-datacenter
 external_configuration: true
 only_add_to_inventory: false

--- a/topologies/beta-datacenter/topo_build.yml
+++ b/topologies/beta-datacenter/topo_build.yml
@@ -2,7 +2,7 @@ cloud_service: aws:adc
 default_interfaces: 8
 default_ami_name: 4.24.0F
 cvp_instance: singlenode
-cvp_version: 2020.1.0-RC1
+cvp_version: 2020.1.0
 topology_name: beta-datacenter
 external_configuration: true
 only_add_to_inventory: false

--- a/topologies/beta-datacenter/topo_build.yml
+++ b/topologies/beta-datacenter/topo_build.yml
@@ -3,7 +3,6 @@ default_interfaces: 8
 default_ami_name: 4.24.0F
 cvp_instance: singlenode
 cvp_version: 2020.1.0-RC1
-
 topology_name: beta-datacenter
 external_configuration: true
 only_add_to_inventory: false

--- a/topologies/beta-routing/topo_build.yml
+++ b/topologies/beta-routing/topo_build.yml
@@ -2,7 +2,7 @@ cloud_service: aws:adc
 default_interfaces: 8
 default_ami_name: 4.24.0F
 cvp_instance: singlenode
-cvp_version: 2019.1.4
+cvp_version: 2020.1.0
 topology_name: beta-routing
 external_configuration: true
 only_add_to_inventory: false


### PR DESCRIPTION
Updating CVP to 2020.1.0-EFT6 in the Beta Datacenter topology.  This is for testing of our scripts on the upcoming Green release.