### PR TITLE
Changed hash for arista user pw to align with CVP

### DIFF
--- a/topologies/beta-routing/configlets/ATD-INFRA
+++ b/topologies/beta-routing/configlets/ATD-INFRA
@@ -13,7 +13,7 @@ aaa authentication login default local
 aaa authorization exec default local
 !
 username admin privilege 15 role network-admin secret 5 $1$5O85YVVn$HrXcfOivJEnISTMb6xrJc.
-username arista privilege 15 secret 5 $1$4VjIjfd1$XkUVulbNDESHFzcxDU.Tk1
+username arista privilege 15 secret sha512 $6$QyW6u6zxDa.jAxA3$QFY6Hr681QjQRmi.3R0VTsbC3wlWsBivdoXTFF6IfnaLXDjzXaIMQ8/zdZP4VxtvR.MDDryRbEBAu6.1qMrOt.
 username arista ssh-key ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6bJB3TkBEQZ9jNyO1kbdU0P20gZ1D72CvsPNZ5S4bbciBNTT/MHX8GwyLmM9k+ihaHK2JtRhWFcdsm9MojRgjAuzw4wn/6pa92y/93GvaYL//dOBXrHctZsX3PX7TZFL9VVBVA8aFp5iXxEM8uyKWhxnBo/D0eR25Jed4gHVHQMi6Hyh7eKRpE3E6kvRlSkhNikZ5EwdoM7lg2i6rjf7+o3G6isGtxliMZD98N6qWW79U6euS072qkK/q3dfgyHdd8a8MD5VLWbYR9ikhKwpXAmxcFn5aRllqXJ++QAW0NO78noI91ICRxpAuQSzgrntdwXdyFWiqyiD3AxK28qWZ arista@labaccess
 !
 event-handler iptables-vxlan


### PR DESCRIPTION
This is for the beta routing topology only at this time just to get it up and running for testing.