### PR TITLE
updated password has for arista user.

### DIFF
--- a/topologies/datacenter-latest/configlets/ATD-INFRA
+++ b/topologies/datacenter-latest/configlets/ATD-INFRA
@@ -6,7 +6,7 @@ aaa authentication login default local
 aaa authorization exec default local
 !
 username admin privilege 15 role network-admin secret 5 $1$5O85YVVn$HrXcfOivJEnISTMb6xrJc.
-username arista privilege 15 secret 5 $1$4VjIjfd1$XkUVulbNDESHFzcxDU.Tk1
+username arista privilege 15 role network-admin secret sha512 $6$tk41vwYg5ZT4iTYK$CC/uNnDsdC/aZ2B57bfnIas5cEKe/kY9lifwbgvi0Qo.9AizVZgqFUnBEUbOxMFEvSa7ChVebjLmqebmG/OCD/
 !
 username arista ssh-key ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6bJB3TkBEQZ9jNyO1kbdU0P20gZ1D72CvsPNZ5S4bbciBNTT/MHX8GwyLmM9k+ihaHK2JtRhWFcdsm9MojRgjAuzw4wn/6pa92y/93GvaYL//dOBXrHctZsX3PX7TZFL9VVBVA8aFp5iXxEM8uyKWhxnBo/D0eR25Jed4gHVHQMi6Hyh7eKRpE3E6kvRlSkhNikZ5EwdoM7lg2i6rjf7+o3G6isGtxliMZD98N6qWW79U6euS072qkK/q3dfgyHdd8a8MD5VLWbYR9ikhKwpXAmxcFn5aRllqXJ++QAW0NO78noI91ICRxpAuQSzgrntdwXdyFWiqyiD3AxK28qWZ arista@labaccess
 !

--- a/topologies/routing/configlets/ATD-INFRA
+++ b/topologies/routing/configlets/ATD-INFRA
@@ -13,7 +13,7 @@ aaa authentication login default local
 aaa authorization exec default local
 !
 username admin privilege 15 role network-admin secret 5 $1$5O85YVVn$HrXcfOivJEnISTMb6xrJc.
-username arista privilege 15 secret 5 $1$4VjIjfd1$XkUVulbNDESHFzcxDU.Tk1
+username arista privilege 15 role network-admin secret sha512 $6$tk41vwYg5ZT4iTYK$CC/uNnDsdC/aZ2B57bfnIas5cEKe/kY9lifwbgvi0Qo.9AizVZgqFUnBEUbOxMFEvSa7ChVebjLmqebmG/OCD/
 username arista ssh-key ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6bJB3TkBEQZ9jNyO1kbdU0P20gZ1D72CvsPNZ5S4bbciBNTT/MHX8GwyLmM9k+ihaHK2JtRhWFcdsm9MojRgjAuzw4wn/6pa92y/93GvaYL//dOBXrHctZsX3PX7TZFL9VVBVA8aFp5iXxEM8uyKWhxnBo/D0eR25Jed4gHVHQMi6Hyh7eKRpE3E6kvRlSkhNikZ5EwdoM7lg2i6rjf7+o3G6isGtxliMZD98N6qWW79U6euS072qkK/q3dfgyHdd8a8MD5VLWbYR9ikhKwpXAmxcFn5aRllqXJ++QAW0NO78noI91ICRxpAuQSzgrntdwXdyFWiqyiD3AxK28qWZ arista@labaccess
 !
 event-handler iptables-vxlan


### PR DESCRIPTION
The arista user password hashes weren't updated in routing and datacenter-latest ATD-INFRA configlets. This PR updates the hash to work with the new password.