### PR TITLE
No cvp prov

### DIFF
--- a/labvm/services/atdFiles/atdFiles.sh
+++ b/labvm/services/atdFiles/atdFiles.sh
@@ -27,7 +27,7 @@ curl -sL https://deb.nodesource.com/setup_14.x | sudo bash -
 apt install python3-pip nodejs -y
 
 # Install python3 ruamel.yaml
-pip3 install ruamel.yaml bs4 tornado
+pip3 install ruamel.yaml bs4 tornado scp paramiko
 
 # Setup NPM and webssh2
 npm install forever -g

--- a/labvm/services/cvpUpdater/cvpUpdater.py
+++ b/labvm/services/cvpUpdater/cvpUpdater.py
@@ -264,12 +264,18 @@ if __name__ == '__main__':
     syslog.openlog(logoption=syslog.LOG_PID)
     pS("OK","Starting...")
 
-    if not path.exists(CVP_CONFIG_FIILE):
-        # Start the main Service
-        pS("OK","Initial ATD Topo Boot")
-        main()
-        with open(CVP_CONFIG_FIILE,'w') as tf:
-            tf.write("CVP_CONFIGURED\n")
-        pS("OK","Completed CVP Configuration")
+    atd_yaml = getTopoInfo(topo_file)
+    if 'cvp' in atd_yaml['nodes']:
+        if not path.exists(CVP_CONFIG_FIILE):
+            # Start the main Service
+            pS("OK","Initial ATD Topo Boot")
+            main()
+            with open(CVP_CONFIG_FIILE,'w') as tf:
+                tf.write("CVP_CONFIGURED\n")
+            pS("OK","Completed CVP Configuration")
+        else:
+            pS("OK","CVP is already configured")
     else:
-        pS("OK","CVP is already configured")
+        pS("INFO","CVP is not present in this topology, disabling cvpUpdater")
+        os.system("systemctl disable cvpUpdater")
+        os.system("systemctl stop cvpUpdater")

--- a/labvm/services/cvpUpdater/cvpUpdater.py
+++ b/labvm/services/cvpUpdater/cvpUpdater.py
@@ -277,5 +277,5 @@ if __name__ == '__main__':
             pS("OK","CVP is already configured")
     else:
         pS("INFO","CVP is not present in this topology, disabling cvpUpdater")
-        os.system("systemctl disable cvpUpdater")
-        os.system("systemctl stop cvpUpdater")
+        system("systemctl disable cvpUpdater")
+        system("systemctl stop cvpUpdater")

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -225,7 +225,7 @@ def main(argv):
         f.close()
 
         cvpConfigs = cvpInfo["cvp_info"]["configlets"]
-        infraConfigs = cvpInfo["containers"]["Tenant"]
+        infraConfigs = cvpConfigs["containers"]["Tenant"]
 
         print("Setting up {0} lab").format(lab)
         for node in accessinfo["nodes"]["veos"]:

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -227,7 +227,7 @@ def main(argv):
         print("Setting up {0} lab").format(lab)
         for node in accessinfo["nodes"]["veos"]:
             hostname = node["hostname"]
-            baseConfigs = cvpInfo["cvpinfo"]["configlets"]["netelements"]
+            baseConfigs = cvpInfo["cvp_info"]["configlets"]["netelements"]
             print("Config for {0}: {1} {2}").format(hostname,baseConfigs[hostname],labconfiglets[lab][hostname])
 
 

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -202,7 +202,7 @@ def main(argv):
     else:
         print("Setting up {0} lab")
         for node in accessinfo["nodes"]["veos"]:
-            print("Config for {0}: ").format(node)
+            print("Config for {0}: ").format(node["hostname"])
 
 
 

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -12,9 +12,11 @@ from scp import SCPClient
 DEBUG = False
 
 # Cmds to copy bare startup to running
-dev_cmds = """enable
-copy startup-config running-config
+cpRunStart = """enable
 copy running-config startup-config
+"""
+cpStartRun = """enable
+copy startup-config running-config
 """
 # Cmds to grab ZTP status
 ztp_cmds = """enable
@@ -142,7 +144,8 @@ def pushBareConfig(veos_host, veos_ip, veos_config):
     veos_ssh.connect(hostname=veos_ip, username="root", password="", port="50001")
     scp = SCPClient(veos_ssh.get_transport())
     scp.put(deviceConfig,remote_path="/mnt/flash/startup-config")
-    veos_ssh.exec_command('FastCli -c "{0}"'.format(dev_cmds))
+    veos_ssh.exec_command('FastCli -c "{0}"'.format(cpStartRun))
+    veos_ssh.exec_command('FastCli -c "{0}"'.format(cpRunStart))
     stdin, stdout, stderr = veos_ssh.exec_command('FastCli -c "{0}"'.format(ztp_cmds))
     ztp_out = stdout.readlines()
     if 'Active' in ztp_out[0]:

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -177,7 +177,8 @@ cvx
    no shutdown
    service vxlan
       no shutdown
-!"""
+!
+"""
 
 def pushBareConfig(veos_host, veos_ip, veos_config):
     """

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -173,7 +173,7 @@ def main(argv):
             pS("INFO", "Setting {0} topology to {1} setup".format(accessinfo['topology'], lab))
             update_topology(cvp_clnt, lab, labconfiglets)
         else:
-        print_usage(options)
+            print_usage(options)
         
         # Execute all tasks generated from reset_devices()
         print('Gathering task information...')

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -200,7 +200,9 @@ def main(argv):
             else:
                 pass
     else:
-        print("no CVP")   
+        print("Setting up {0} lab")
+        for node in accessinfo["nodes"]:
+            print("Config for {0}: ").format(node)
 
 
 

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -133,7 +133,7 @@ def pushBareConfig(veos_host, veos_ip, veos_config):
     veos_ssh = paramiko.SSHClient()
     veos_ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     veos_ssh.connect(hostname=veos_ip, username="root", password="", port="50001")
-    veos_ssh.exec_command("echo '{0}' > /mnt/flash/startup-config".format(veos_config2))
+    veos_ssh.exec_command("echo '{0}' > /mnt/flash/startup-config".format(veos_config))
     veos_ssh.exec_command('FastCli -c "{0}"'.format(dev_cmds))
     stdin, stdout, stderr = veos_ssh.exec_command('FastCli -c "{0}"'.format(ztp_cmds))
     ztp_out = stdout.readlines()

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -6,6 +6,7 @@ import urllib3
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 from rcvpapi.rcvpapi import *
 import yaml, syslog, time
+import paramiko
 
 DEBUG = False
 

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -253,7 +253,7 @@ def main(argv):
         cvpConfigs = cvpInfo["cvp_info"]["configlets"]
         infraConfigs = cvpConfigs["containers"]["Tenant"]
 
-        print("Setting up {0} lab".format(lab))
+        pS("INFO","Setting up {0} lab".format(lab))
         for node in accessinfo["nodes"]["veos"]:
             deviceConfig = ""
             hostname = node["hostname"]
@@ -263,7 +263,7 @@ def main(argv):
             for config in configs:
                 with open('/tmp/atd/topologies/{0}/configlets/{1}'.format(accessinfo['topology'], config), 'r') as configlet:
                     deviceConfig += configlet.read()
-            print("Pushing {0} config for {1} on IP {2} with configlets: {3}".format(lab,hostname,node["ip"],configs))
+            pS("INFO","Pushing {0} config for {1} on IP {2} with configlets: {3}".format(lab,hostname,node["ip"],configs))
             pushBareConfig(hostname, node["ip"], deviceConfig)
             
 

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -129,6 +129,7 @@ def pushBareConfig(veos_host, veos_ip, veos_config):
     """
     Pushes a bare config to the EOS device.
     """
+    print(format(veos_config))
     DEVREBOOT = False
     veos_ssh = paramiko.SSHClient()
     veos_ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -144,6 +144,7 @@ def pushBareConfig(veos_host, veos_ip, veos_config):
     veos_ssh.connect(hostname=veos_ip, username="root", password="", port="50001")
     scp = SCPClient(veos_ssh.get_transport())
     scp.put(deviceConfig,remote_path="/mnt/flash/startup-config")
+    scp.close()
     veos_ssh.exec_command('FastCli -c "{0}"'.format(cpStartRun))
     veos_ssh.exec_command('FastCli -c "{0}"'.format(cpRunStart))
     stdin, stdout, stderr = veos_ssh.exec_command('FastCli -c "{0}"'.format(ztp_cmds))
@@ -265,7 +266,6 @@ def main(argv):
             print("Pushing {0} config for {1} on IP {2} with configlets: {3}".format(lab,hostname,node["ip"],configs))
             pushBareConfig(hostname, node["ip"], deviceConfig)
             
-
 
 if __name__ == '__main__':
     syslog.openlog(logoption=syslog.LOG_PID)

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -229,6 +229,7 @@ def main(argv):
 
         print("Setting up {0} lab").format(lab)
         for node in accessinfo["nodes"]["veos"]:
+            deviceConfig = ""
             hostname = node["hostname"]
             baseConfigs = cvpConfigs["netelements"]
             configs = baseConfigs[hostname] + infraConfigs + labconfiglets[lab][hostname]

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -10,8 +10,17 @@ import paramiko
 
 DEBUG = False
 
+# Cmds to copy bare startup to running
 dev_cmds = """enable
 copy startup-config running-config
+"""
+# Cmds to grab ZTP status
+ztp_cmds = """enable
+show zerotouch | grep ZeroTouch
+"""
+# Cancel ZTP
+ztp_cancel = """enable
+zerotouch cancel
 """
 
 def remove_configlets(client, device, mext=None):
@@ -125,7 +134,7 @@ def pushBareConfig(veos_host, veos_ip, veos_config):
     veos_ssh = paramiko.SSHClient()
     veos_ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     veos_ssh.connect(hostname=veos_ip, username="root", password="", port="50001")
-    veos_ssh.exec_command("echo '{0}' | tee /mnt/flash/startup-config".format(veos_config))
+    veos_ssh.exec_command("echo 'testing' | tee /mnt/flash/startup-config".format(veos_config))
     veos_ssh.exec_command('FastCli -c "{0}"'.format(dev_cmds))
     stdin, stdout, stderr = veos_ssh.exec_command('FastCli -c "{0}"'.format(ztp_cmds))
     ztp_out = stdout.readlines()

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -129,7 +129,6 @@ def pushBareConfig(veos_host, veos_ip, veos_config):
     """
     Pushes a bare config to the EOS device.
     """
-    veos_config = "mytest"
     DEVREBOOT = False
     veos_ssh = paramiko.SSHClient()
     veos_ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -126,16 +126,16 @@ def pS(mstat,mtype):
         print("[{0}] {1}".format(mstat,mmes.expandtabs(7 - len(mstat))))
 
 veos_config2 = """daemon TerminAttr
-  exec /usr/bin/TerminAttr -ingestgrpcurl=192.168.0.5:9910 -taillogs -ingestauth=key,1a38fe7df56879d685e51b6f0ff86327 -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+  exec -usr-bin-TerminAttr -ingestgrpcurl=192.168.0.5:9910 -taillogs -ingestauth=key,1a38fe7df56879d685e51b6f0ff86327 -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=-Sysdb-cell-1-agent,-Sysdb-cell-2-agent
   no shutdown
 !
 aaa authentication login default local
 aaa authorization exec default local
 !
 username admin privilege 15 role network-admin secret 5 $1$5O85YVVn$HrXcfOivJEnISTMb6xrJc.
-username arista privilege 15 role network-admin secret sha512 $6$tk41vwYg5ZT4iTYK$CC/uNnDsdC/aZ2B57bfnIas5cEKe/kY9lifwbgvi0Qo.9AizVZgqFUnBEUbOxMFEvSa7ChVebjLmqebmG/OCD/
+username arista privilege 15 role network-admin secret sha512 $6$tk41vwYg5ZT4iTYK$CC-uNnDsdC-aZ2B57bfnIas5cEKe-kY9lifwbgvi0Qo.9AizVZgqFUnBEUbOxMFEvSa7ChVebjLmqebmG-OCD-
 !
-username arista ssh-key ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6bJB3TkBEQZ9jNyO1kbdU0P20gZ1D72CvsPNZ5S4bbciBNTT/MHX8GwyLmM9k+ihaHK2JtRhWFcdsm9MojRgjAuzw4wn/6pa92y/93GvaYL//dOBXrHctZsX3PX7TZFL9VVBVA8aFp5iXxEM8uyKWhxnBo/D0eR25Jed4gHVHQMi6Hyh7eKRpE3E6kvRlSkhNikZ5EwdoM7lg2i6rjf7+o3G6isGtxliMZD98N6qWW79U6euS072qkK/q3dfgyHdd8a8MD5VLWbYR9ikhKwpXAmxcFn5aRllqXJ++QAW0NO78noI91ICRxpAuQSzgrntdwXdyFWiqyiD3AxK28qWZ arista@labaccess
+username arista ssh-key ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6bJB3TkBEQZ9jNyO1kbdU0P20gZ1D72CvsPNZ5S4bbciBNTT-MHX8GwyLmM9k+ihaHK2JtRhWFcdsm9MojRgjAuzw4wn-6pa92y-93GvaYL--dOBXrHctZsX3PX7TZFL9VVBVA8aFp5iXxEM8uyKWhxnBo-D0eR25Jed4gHVHQMi6Hyh7eKRpE3E6kvRlSkhNikZ5EwdoM7lg2i6rjf7+o3G6isGtxliMZD98N6qWW79U6euS072qkK-q3dfgyHdd8a8MD5VLWbYR9ikhKwpXAmxcFn5aRllqXJ++QAW0NO78noI91ICRxpAuQSzgrntdwXdyFWiqyiD3AxK28qWZ arista@labaccess
 !
 tacacs-server key 7 070E33455D1D18
 tacacs-server host 192.168.0.4
@@ -161,13 +161,13 @@ vlan 34
 hostname cvx01
 !
 interface Management1
-   ip address 192.168.0.44/24
+   ip address 192.168.0.44-24
    no lldp transmit
    no lldp receive
 !
 dns domain arista.lab
 ip routing
-!! ip route 0.0.0.0/0 192.168.0.1
+!! ip route 0.0.0.0-0 192.168.0.1
 !
 management api http-commands
    no shutdown
@@ -178,7 +178,7 @@ cvx
    service vxlan
       no shutdown
 !
-EOF"""
+"""
 
 def pushBareConfig(veos_host, veos_ip, veos_config):
     """

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -232,6 +232,7 @@ def main(argv):
             hostname = node["hostname"]
             baseConfigs = cvpConfigs["netelements"]
             configs = baseConfigs[hostname] + infraConfigs + labconfiglets[lab][hostname]
+            configs = list(dict.fromkeys(configs))
             print("Config for {0}: {1}").format(hostname,configs)
 
 

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -157,7 +157,7 @@ def main(argv):
     options = menuoptions['lab_list']
 
     # Parse command arguments
-    lab = argv[3]
+    lab = str(argv[3])
     # try:
     #     opts, args = getopt.getopt(argv,"ht:",["topology="])
     # except getopt.GetOptError:

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -224,11 +224,14 @@ def main(argv):
         cvpInfo = yaml.safe_load(f)
         f.close()
 
+        cvpConfigs = cvpInfo["cvp_info"]["configlets"]
+        infraConfigs = cvpInfo["containers"]["Tenant"]
+
         print("Setting up {0} lab").format(lab)
         for node in accessinfo["nodes"]["veos"]:
             hostname = node["hostname"]
-            baseConfigs = cvpInfo["cvp_info"]["configlets"]["netelements"]
-            configs = baseConfigs[hostname] + labconfiglets[lab][hostname]
+            baseConfigs = cvpConfigs["netelements"]
+            configs = baseConfigs[hostname] + infraConfigs + labconfiglets[lab][hostname]
             print("Config for {0}: {1}").format(hostname,configs)
 
 

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -157,7 +157,7 @@ def main(argv):
     options = menuoptions['lab_list']
 
     # Parse command arguments
-    lab = str(argv[3])
+    lab = argv[3]
     # try:
     #     opts, args = getopt.getopt(argv,"ht:",["topology="])
     # except getopt.GetOptError:
@@ -241,7 +241,7 @@ def main(argv):
         cvpConfigs = cvpInfo["cvp_info"]["configlets"]
         infraConfigs = cvpConfigs["containers"]["Tenant"]
 
-        print("Setting up {0} lab").format(lab)
+        print("Setting up {0} lab".format(lab))
         for node in accessinfo["nodes"]["veos"]:
             deviceConfig = ""
             hostname = node["hostname"]
@@ -251,7 +251,7 @@ def main(argv):
             for config in configs:
                 with open('/tmp/atd/topologies/{0}/configlets/{1}'.format(accessinfo['topology'], config), 'r') as configlet:
                     deviceConfig += configlet.read()
-            print("Pushing {0} config for {1} on IP {2} with configlets: {3}").format(lab,hostname,node["ip"],configs)
+            print("Pushing {0} config for {1} on IP {2} with configlets: {3}".format(lab,hostname,node["ip"],configs))
             pushBareConfig(hostname, node["ip"], deviceConfig)
             
 

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -234,11 +234,11 @@ def main(argv):
             baseConfigs = cvpConfigs["netelements"]
             configs = baseConfigs[hostname] + infraConfigs + labconfiglets[lab][hostname]
             configs = list(dict.fromkeys(configs))
-            print("Config for {0}:").format(hostname)
             for config in configs:
                 with open('/tmp/atd/topologies/{0}/configlets/{1}'.format(accessinfo['topology'], config), 'r') as configlet:
                     deviceConfig += configlet.read()
-            print(deviceConfig)
+            print("Pushing {0} config for {1} with configlets: {2}").format(lab,hostname,configs)
+            pushBareConfig(hostname, node["ip"], deviceConfig)
             
 
 

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -134,7 +134,7 @@ def pushBareConfig(veos_host, veos_ip, veos_config):
     veos_ssh = paramiko.SSHClient()
     veos_ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     veos_ssh.connect(hostname=veos_ip, username="root", password="", port="50001")
-    veos_ssh.exec_command("echo 'testing' | tee /mnt/flash/startup-config".format(veos_config))
+    veos_ssh.exec_command("echo '{0}' > /mnt/flash/startup-config".format(veos_config))
     veos_ssh.exec_command('FastCli -c "{0}"'.format(dev_cmds))
     stdin, stdout, stderr = veos_ssh.exec_command('FastCli -c "{0}"'.format(ztp_cmds))
     ztp_out = stdout.readlines()

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -219,10 +219,16 @@ def main(argv):
             else:
                 pass
     else:
+        # Open up defaults
+        f = open('/home/arista/cvp/cvp_info.yaml')
+        cvpInfo = yaml.safe_load(f)
+        f.close()
+
         print("Setting up {0} lab").format(lab)
         for node in accessinfo["nodes"]["veos"]:
             hostname = node["hostname"]
-            print("Config for {0}: {1}").format(hostname,labconfiglets[lab][hostname])
+            baseConfigs = cvpInfo["configlets"]["netelements"]
+            print("Config for {0}: {1} {2}").format(hostname,baseConfigs[hostname],labconfiglets[lab][hostname])
 
 
 if __name__ == '__main__':

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -227,7 +227,7 @@ def main(argv):
         print("Setting up {0} lab").format(lab)
         for node in accessinfo["nodes"]["veos"]:
             hostname = node["hostname"]
-            baseConfigs = cvpInfo["configlets"]["netelements"]
+            baseConfigs = cvpInfo["cvpinfo"]["configlets"]["netelements"]
             print("Config for {0}: {1} {2}").format(hostname,baseConfigs[hostname],labconfiglets[lab][hostname])
 
 

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -198,6 +198,11 @@ def main(argv):
     # List of configlets
     labconfiglets = menuoptions['labconfiglets']
 
+    if lab in options:
+        pS("INFO", "Setting {0} topology to {1} setup".format(accessinfo['topology'], lab))
+    else:
+        print_usage(options)
+
     # Check if the topo has CVP
     if 'cvp' in accessinfo['nodes']:
         # Adding new connection to CVP via rcvpapi
@@ -212,13 +217,8 @@ def main(argv):
                         pS("ERROR", "CVP is currently unavailable....Retrying in 30 seconds.")
                         time.sleep(30)
 
-        # Make sure option chosen is valid, then configure the topology
-        print("Please wait while the {0} lab is prepared...".format(lab))
-        if lab in options:
-            pS("INFO", "Setting {0} topology to {1} setup".format(accessinfo['topology'], lab))
-            update_topology(cvp_clnt, lab, labconfiglets)
-        else:
-            print_usage(options)
+        # Config the topology
+        update_topology(cvp_clnt, lab, labconfiglets)
         
         # Execute all tasks generated from reset_devices()
         print('Gathering task information...')

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -201,7 +201,7 @@ def main(argv):
                 pass
     else:
         print("Setting up {0} lab")
-        for node in accessinfo["nodes"]:
+        for node in accessinfo["nodes"]["veos"]:
             print("Config for {0}: ").format(node)
 
 

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -178,7 +178,7 @@ cvx
    service vxlan
       no shutdown
 !
-"""
+EOF"""
 
 def pushBareConfig(veos_host, veos_ip, veos_config):
     """

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -10,6 +10,10 @@ import paramiko
 
 DEBUG = False
 
+dev_cmds = """enable
+copy startup-config running-config
+"""
+
 def remove_configlets(client, device, mext=None):
     """
     Removes all configlets except the ones defined here or starting with SYS_
@@ -116,6 +120,7 @@ def pushBareConfig(veos_host, veos_ip, veos_config):
     """
     Pushes a bare config to the EOS device.
     """
+
     DEVREBOOT = False
     veos_ssh = paramiko.SSHClient()
     veos_ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -103,14 +103,14 @@ def update_topology(client, lab, configlets):
 
 def print_usage(topologies):
     # Function to print help menu with valid topologies
-    print 'Usage:'
-    print ''
-    print 'ConfigureTopology.py - No options will reset the topology to the base'
-    print '  -t Topology to push out to devices'
-    print ''
-    print 'Valid topologies are:'
-    print ', '.join(topologies)
-    print ''
+    print('Usage:')
+    print('')
+    print('ConfigureTopology.py - No options will reset the topology to the base')
+    print('  -t Topology to push out to devices')
+    print('')
+    print('Valid topologies are:')
+    print(', '.join(topologies))
+    print('')
     quit()
 
 def pS(mstat,mtype):
@@ -124,61 +124,6 @@ def pS(mstat,mtype):
     syslog.syslog("[{0}] {1}".format(mstat,mmes.expandtabs(7 - len(mstat))))
     if DEBUG:
         print("[{0}] {1}".format(mstat,mmes.expandtabs(7 - len(mstat))))
-
-veos_config2 = """daemon TerminAttr
-  exec -usr-bin-TerminAttr -ingestgrpcurl=192.168.0.5:9910 -taillogs -ingestauth=key,1a38fe7df56879d685e51b6f0ff86327 -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=-Sysdb-cell-1-agent,-Sysdb-cell-2-agent
-  no shutdown
-!
-aaa authentication login default local
-aaa authorization exec default local
-!
-username admin privilege 15 role network-admin secret 5 $1$5O85YVVn$HrXcfOivJEnISTMb6xrJc.
-username arista privilege 15 role network-admin secret sha512 $6$tk41vwYg5ZT4iTYK$CC-uNnDsdC-aZ2B57bfnIas5cEKe-kY9lifwbgvi0Qo.9AizVZgqFUnBEUbOxMFEvSa7ChVebjLmqebmG-OCD-
-!
-username arista ssh-key ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6bJB3TkBEQZ9jNyO1kbdU0P20gZ1D72CvsPNZ5S4bbciBNTT-MHX8GwyLmM9k+ihaHK2JtRhWFcdsm9MojRgjAuzw4wn-6pa92y-93GvaYL--dOBXrHctZsX3PX7TZFL9VVBVA8aFp5iXxEM8uyKWhxnBo-D0eR25Jed4gHVHQMi6Hyh7eKRpE3E6kvRlSkhNikZ5EwdoM7lg2i6rjf7+o3G6isGtxliMZD98N6qWW79U6euS072qkK-q3dfgyHdd8a8MD5VLWbYR9ikhKwpXAmxcFn5aRllqXJ++QAW0NO78noI91ICRxpAuQSzgrntdwXdyFWiqyiD3AxK28qWZ arista@labaccess
-!
-tacacs-server key 7 070E33455D1D18
-tacacs-server host 192.168.0.4
-!
-management api http-commands
-   no shutdown
-!
-event-handler iptables-vxlan
-   trigger on-boot
-   action bash sudo iptables -I INPUT 1 -p udp --dport 4789 -j ACCEPT
-   asynchronous
-!
-event-handler ovs-restart
-   trigger on-boot
-   action bash sudo systemctl restart openvswitch
-   delay 30
-   asynchronous
-!
-vlan 12
-!
-vlan 34
-!
-hostname cvx01
-!
-interface Management1
-   ip address 192.168.0.44-24
-   no lldp transmit
-   no lldp receive
-!
-dns domain arista.lab
-ip routing
-!! ip route 0.0.0.0-0 192.168.0.1
-!
-management api http-commands
-   no shutdown
-   protocol http
-!
-cvx
-   no shutdown
-   service vxlan
-      no shutdown
-!
-"""
 
 def pushBareConfig(veos_host, veos_ip, veos_config):
     """

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -238,7 +238,7 @@ def main(argv):
             for config in configs:
                 with open('/tmp/atd/topologies/{0}/configlets/{1}'.format(accessinfo['topology'], config), 'r') as configlet:
                     deviceConfig += configlet.read()
-            print("Pushing {0} config for {1} with configlets: {2}").format(lab,hostname,configs)
+            print("Pushing {0} config for {1} on IP {3} with configlets: {2}").format(lab,hostname,configs,node["ip"])
             pushBareConfig(hostname, node["ip"], deviceConfig)
             
 

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -129,7 +129,7 @@ def pushBareConfig(veos_host, veos_ip, veos_config):
     """
     Pushes a bare config to the EOS device.
     """
-
+    veos_config = "mytest"
     DEVREBOOT = False
     veos_ssh = paramiko.SSHClient()
     veos_ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -233,7 +233,12 @@ def main(argv):
             baseConfigs = cvpConfigs["netelements"]
             configs = baseConfigs[hostname] + infraConfigs + labconfiglets[lab][hostname]
             configs = list(dict.fromkeys(configs))
-            print("Config for {0}: {1}").format(hostname,configs)
+            print("Config for {0}:").format(hostname)
+            for config in configs:
+                with open('/tmp/atd/topologies/{0}/configlets/{1}'.format(accessinfo['topology'], config), 'r') as configlet:
+                    deviceConfig += configlet.read()
+            print(deviceConfig)
+            
 
 
 if __name__ == '__main__':

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -149,12 +149,11 @@ def main(argv):
     # if enableControls2:
     #   options.update(menuoptions['media-options'])
 
- 
-
-
-
     # List of configlets
     labconfiglets = menuoptions['labconfiglets']
+
+    # Check if the topo has CVP
+    
 
     # Adding new connection to CVP via rcvpapi
     cvp_clnt = ''

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -199,8 +199,8 @@ def main(argv):
                 all_tasks_completed = True
             else:
                 pass
-        else:
-            print("no CVP")   
+    else:
+        print("no CVP")   
 
 
 

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -222,7 +222,7 @@ def main(argv):
         print("Setting up {0} lab").format(lab)
         for node in accessinfo["nodes"]["veos"]:
             hostname = node["hostname"]
-            print("Config for {0}: {1}").format(hostname).format(labconfiglets[lab][hostname])
+            print("Config for {0}: {1}").format(hostname,labconfiglets[lab][hostname])
 
 
 if __name__ == '__main__':

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -14,6 +14,7 @@ DEBUG = False
 # Cmds to copy bare startup to running
 dev_cmds = """enable
 copy startup-config running-config
+copy running-config startup-config
 """
 # Cmds to grab ZTP status
 ztp_cmds = """enable

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -228,7 +228,8 @@ def main(argv):
         for node in accessinfo["nodes"]["veos"]:
             hostname = node["hostname"]
             baseConfigs = cvpInfo["cvp_info"]["configlets"]["netelements"]
-            print("Config for {0}: {1} {2}").format(hostname,baseConfigs[hostname],labconfiglets[lab][hostname])
+            configs = baseConfigs[hostname] + labconfiglets[lab][hostname]
+            print("Config for {0}: {1}").format(hostname,configs)
 
 
 if __name__ == '__main__':

--- a/topologies/all/ConfigureTopology.py
+++ b/topologies/all/ConfigureTopology.py
@@ -125,7 +125,7 @@ def pS(mstat,mtype):
     if DEBUG:
         print("[{0}] {1}".format(mstat,mmes.expandtabs(7 - len(mstat))))
 
-veos_config2 = 'daemon TerminAttr
+veos_config2 = """daemon TerminAttr
   exec /usr/bin/TerminAttr -ingestgrpcurl=192.168.0.5:9910 -taillogs -ingestauth=key,1a38fe7df56879d685e51b6f0ff86327 -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
   no shutdown
 !
@@ -177,7 +177,7 @@ cvx
    no shutdown
    service vxlan
       no shutdown
-!'
+!"""
 
 def pushBareConfig(veos_host, veos_ip, veos_config):
     """


### PR DESCRIPTION
This change removes the requirement of CVP to provision the topology and uses paramiko to build and push configs to the devices, should streamline provisioning in the event CVP isn't present

ConfigureTopology was changed to be compatible with existing menu and adapt whether or not CVP is present
atdFiles.sh was edited to add necessary libraries
cvpUpdater.py was edited to check if 'cvp' is present in the nodes section of ACCESS_INFO