### PR TITLE
fixed user permission and disabling cvpUpdater to fix reboot of nodes

### DIFF
--- a/labvm/services/cvpUpdater/cvpUpdater.py
+++ b/labvm/services/cvpUpdater/cvpUpdater.py
@@ -275,6 +275,6 @@ if __name__ == '__main__':
         else:
             pS("OK","CVP is already configured")
     else:
-        pS("INFO","CVP is not present in this topology, disabling cvpUpdater")
-        system("systemctl disable cvpUpdater")
-        system("systemctl stop cvpUpdater")
+        pS("INFO","CVP is not present in this topology, preventing future run of cvpUpdater")
+        with open(CVP_CONFIG_FILE,'w') as tf:
+            tf.write("CVP_CONFIGURED\n")

--- a/labvm/services/cvpUpdater/cvpUpdater.service
+++ b/labvm/services/cvpUpdater/cvpUpdater.service
@@ -5,6 +5,7 @@ After=atdFiles.service
 [Service]
 Type=forking
 ExecStart=/usr/local/bin/cvpUpdater.py
+User=arista
 TimeoutStartSec=900
 Restart=on-failure
 RestartSec=60


### PR DESCRIPTION
`cvpUpdater.service` used to run as the arista user in the past. Since it was changed to the `root` user, the `cvpUpdater.py` script could not ssh to each vEOS node to reboot with the incorrect ssh keys.

For `cvpUpdater.py` service, instead of disabling the `cvpUpdater` service script, which requires root access, we are adding the `.cvpState.txt` file that prevents the script from running in the future.