### PR TITLE
added a wait until configlets directory exists

### DIFF
--- a/labvm/services/cvpUpdater/cvpUpdater.py
+++ b/labvm/services/cvpUpdater/cvpUpdater.py
@@ -109,6 +109,9 @@ def main():
         # ==========================================
         # Add configlets into CVP
         # ==========================================
+        while not path.exists(configlet_location):
+            sleep(FILE_DELAY)
+            pS("INFO", "Configlets directory not found, waiting...")
         if path.exists(configlet_location):
             pS("OK","Configlet directory exists")
             pro_cfglt = listdir(configlet_location)


### PR DESCRIPTION
Added a delay, wait timer for the topology configlet directory to exists. When testing on two beta-dc topologies, one of the topologies ran without the configlet directory present. So it did not upload any configlets. The other ran fine.