### PR TITLE
Patch lab module

### DIFF
--- a/labvm/services/labModule/labModule.py
+++ b/labvm/services/labModule/labModule.py
@@ -12,7 +12,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 topo_file = '/etc/ACCESS_INFO.yaml'
 CVP_CONFIG_FIILE = '/home/arista/.cvpState.txt'
-pDEBUG = True
+pDEBUG = False
 CONFIGURE_TOPOLOGY = "/usr/local/bin/ConfigureTopology.py"
 APP_KEY = 'app'
 sleep_delay = 30
@@ -80,6 +80,7 @@ def main(atd_yaml):
     Parameters:
     atd_yaml = Ruamel.YAML object container of ACCESS_INFO 
     """
+    cvp_clnt = ""
     # Create connection to CVP
     for c_login in atd_yaml['login_info']['cvp']['shell']:
         if c_login['user'] == 'arista':

--- a/labvm/services/labModule/labModule.py
+++ b/labvm/services/labModule/labModule.py
@@ -4,13 +4,18 @@
 from ruamel.yaml import YAML
 from os import path, system
 from time import sleep
+from rcvpapi.rcvpapi import *
 import syslog
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
 
 topo_file = '/etc/ACCESS_INFO.yaml'
 CVP_CONFIG_FIILE = '/home/arista/.cvpState.txt'
 pDEBUG = True
 CONFIGURE_TOPOLOGY = "/usr/local/bin/ConfigureTopology.py"
 APP_KEY = 'app'
+sleep_delay = 30
 
 # Module mapping for default_lab tag to map for use with ConfigureTopology
 MODULES = {
@@ -75,6 +80,30 @@ def main(atd_yaml):
     Parameters:
     atd_yaml = Ruamel.YAML object container of ACCESS_INFO 
     """
+    # Create connection to CVP
+    for c_login in atd_yaml['login_info']['cvp']['shell']:
+        if c_login['user'] == 'arista':
+            while not cvp_clnt:
+                try:
+                    cvp_clnt = CVPCON(atd_yaml['nodes']['cvp'][0]['ip'],c_login['user'],c_login['pw'])
+                    pS("OK","Connected to CVP at {0}".format(atd_yaml['nodes']['cvp'][0]['ip']))
+                except:
+                    pS("ERROR","CVP is currently unavailable....Retrying in {0} seconds.".format(sleep_delay))
+                    sleep(sleep_delay)
+    # Get CVP Inventory and iterate through all connected devices to verify connectivity
+    for vnode in cvp_clnt.inventory:
+        while True:
+            vresponse = cvp_clnt.ipConnectivityTest(cvp_clnt.inventory[vnode]['ipAddress'])
+            if 'data' in vresponse:
+                if vresponse['data'] == 'success':
+                    pS("OK", "{0} is up and reachable at {1}".format(vnode, cvp_clnt.inventory[vnode]['ipAddress']))
+                    break
+            else:
+                pS("INFO", "{0} is NOT reachable at {1}. Sleeping {2} seconds.".format(vnode, cvp_clnt.inventory[vnode]['ipAddress'], sleep_delay))
+                sleep(sleep_delay)
+    pS("OK", "All Devices are registered and reachable.")
+
+    # Continue to configure topology
     lab, mod = atd_yaml[APP_KEY].split('-')
     lab_topo = MODULES[mod]['topo']
     lab_module = MODULES[mod]['module']

--- a/labvm/services/labModule/labModule.service
+++ b/labvm/services/labModule/labModule.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Creates a new lab UI for modules
-After=atdFiles.service
+After=gitConfigletSync.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
Added a connection to CVP in order to get all nodes in inventory and perform an `ipConnectivityTest` API call. 

Before `labModule.py` would start after `cvpUpdater.py` completed. When it would start it will provision the nodes in CVP, but at the time to create and execute the tasks, the nodes were still in a reboot process from `cvpUpdater`. This update makes `labModule.py` wait until all nodes are reachable.

Steps to test on a DC-Latest topo.
1. ssh to the jumphost and get into bash.
2. Run the following commands:
```
sudo echo "app: cvp-mlag" >> /etc/ACCESS_INFO.yaml
sudo sed -i 's/master/patch-labModule/g' /etc/repo.yaml
sudo reboot
```

After the jump host reboots, monitor the service scripts with 
`systemctl status atdFiles` and `systemctl status labModule`
As a note, `labModule` will only start after `atdFiles` has completed. You can also watch in the CVP tasks section for tasks to get created and executed.