### PR TITLE
Updating vEOS version on beta-routing topology

### DIFF
--- a/topologies/beta-routing/topo_build.yml
+++ b/topologies/beta-routing/topo_build.yml
@@ -1,6 +1,6 @@
 cloud_service: aws:adc
 default_interfaces: 8
-default_ami_name: cloud-deploy-veos-4.24.1F
+default_ami_name: cloud-deploy-veos-4.24.2.1F
 cvp_instance: singlenode
 cvp_version: cloud-deploy-cvp-2020.1.1
 topology_name: beta-routing


### PR DESCRIPTION
Increasing vEOS version to Lima.1 for further testing.