### PR TITLE
updated jumphost images to 09-11

### DIFF
--- a/topologies/beta-datacenter/topo_build.yml
+++ b/topologies/beta-datacenter/topo_build.yml
@@ -175,5 +175,5 @@ nodes:
       
   - atd_jump_host:
       neighbors: []
-      ami_name: "cloud-deploy-jh-2020-09-09"
+      ami_name: "cloud-deploy-jh-2020-09-11"
       ip_addr: 192.168.0.4

--- a/topologies/beta-routing/topo_build.yml
+++ b/topologies/beta-routing/topo_build.yml
@@ -299,5 +299,5 @@ nodes:
 
   - atd_jump_host:
       neighbors: []
-      ami_name: "cloud-deploy-jh-2020-08-28"
+      ami_name: "cloud-deploy-jh-2020-09-11"
       ip_addr: "192.168.0.4"

--- a/topologies/datacenter-2019/Datacenter.yml
+++ b/topologies/datacenter-2019/Datacenter.yml
@@ -175,6 +175,6 @@ nodes:
       
   - atd_jump_host:
       neighbors: []
-      ami_name: "cloud-deploy-jh-2020-08-28"
+      ami_name: "cloud-deploy-jh-2020-09-11"
       ip_addr: 192.168.0.4
   

--- a/topologies/datacenter-latest/Datacenter-nocvp.yml
+++ b/topologies/datacenter-latest/Datacenter-nocvp.yml
@@ -174,6 +174,6 @@ nodes:
       
   - atd_jump_host:
       neighbors: []
-      ami_name: "cloud-deploy-jh-2020-08-28"
+      ami_name: "cloud-deploy-jh-2020-09-11"
       ip_addr: 192.168.0.4
   

--- a/topologies/datacenter-latest/Datacenter.yml
+++ b/topologies/datacenter-latest/Datacenter.yml
@@ -175,5 +175,5 @@ nodes:
       
   - atd_jump_host:
       neighbors: []
-      ami_name: "cloud-deploy-jh-2020-08-28"
+      ami_name: "cloud-deploy-jh-2020-09-11"
       ip_addr: 192.168.0.4

--- a/topologies/routing/Routing.yml
+++ b/topologies/routing/Routing.yml
@@ -299,5 +299,5 @@ nodes:
 
   - atd_jump_host:
       neighbors: []
-      ami_name: "cloud-deploy-jh-2020-08-28"
+      ami_name: "cloud-deploy-jh-2020-09-11"
       ip_addr: "192.168.0.4"


### PR DESCRIPTION
Updating the jumphost image to version 09-11. 

This image takes apt, pip and nodejs installs that were in `atdFiles` and are already installed in this jumphost version. This will reduce the overall execution time for atdFiles.