### PR TITLE
Setting print of messages to false so only goes to syslog.

### DIFF
--- a/labvm/services/cvpUpdater/cvpUpdater.py
+++ b/labvm/services/cvpUpdater/cvpUpdater.py
@@ -15,7 +15,7 @@ FILE_DELAY = 10
 
 # Temporary file_path location for CVP Custom info
 cvp_file = '/home/arista/cvp/cvp_info.yaml'
-pDEBUG = True
+pDEBUG = False
 
 # ==================================
 # Start of Global Functions

--- a/labvm/services/labModule/labModule.py
+++ b/labvm/services/labModule/labModule.py
@@ -13,7 +13,7 @@ from ConfigureTopology.ConfigureTopology import ConfigureTopology
 
 topo_file = '/etc/ACCESS_INFO.yaml'
 CVP_CONFIG_FIILE = '/home/arista/.cvpState.txt'
-pDEBUG = True
+pDEBUG = False
 APP_KEY = 'app'
 sleep_delay = 30
 


### PR DESCRIPTION
Setting the print functionality to false within the logging mechanism. This causes duplicate log messages in syslog for that script.