### PR TITLE
updated jumphost images to 2020-12-01 version

### DIFF
--- a/topologies/beta-datacenter/topo_build.yml
+++ b/topologies/beta-datacenter/topo_build.yml
@@ -175,5 +175,5 @@ nodes:
       
   - atd_jump_host:
       neighbors: []
-      ami_name: "cloud-deploy-jh-2020-11-13"
+      ami_name: "cloud-deploy-jh-2020-12-01"
       ip_addr: 192.168.0.4

--- a/topologies/beta-routing/topo_build.yml
+++ b/topologies/beta-routing/topo_build.yml
@@ -299,5 +299,5 @@ nodes:
 
   - atd_jump_host:
       neighbors: []
-      ami_name: "cloud-deploy-jh-2020-11-13"
+      ami_name: "cloud-deploy-jh-2020-12-01"
       ip_addr: "192.168.0.4"

--- a/topologies/datacenter-2019/Datacenter.yml
+++ b/topologies/datacenter-2019/Datacenter.yml
@@ -175,6 +175,6 @@ nodes:
       
   - atd_jump_host:
       neighbors: []
-      ami_name: "cloud-deploy-jh-2020-11-13"
+      ami_name: "cloud-deploy-jh-2020-12-01"
       ip_addr: 192.168.0.4
   

--- a/topologies/datacenter-latest/Datacenter-nocvp.yml
+++ b/topologies/datacenter-latest/Datacenter-nocvp.yml
@@ -174,6 +174,6 @@ nodes:
       
   - atd_jump_host:
       neighbors: []
-      ami_name: "cloud-deploy-jh-2020-11-13"
+      ami_name: "cloud-deploy-jh-2020-12-01"
       ip_addr: 192.168.0.4
   

--- a/topologies/datacenter-latest/Datacenter.yml
+++ b/topologies/datacenter-latest/Datacenter.yml
@@ -175,5 +175,5 @@ nodes:
       
   - atd_jump_host:
       neighbors: []
-      ami_name: "cloud-deploy-jh-2020-11-13"
+      ami_name: "cloud-deploy-jh-2020-12-01"
       ip_addr: 192.168.0.4

--- a/topologies/routing/Routing.yml
+++ b/topologies/routing/Routing.yml
@@ -299,5 +299,5 @@ nodes:
 
   - atd_jump_host:
       neighbors: []
-      ami_name: "cloud-deploy-jh-2020-11-13"
+      ami_name: "cloud-deploy-jh-2020-12-01"
       ip_addr: "192.168.0.4"


### PR DESCRIPTION
Updated the jumphost version to the 2020-12-01 build. This build has UFW disabled, which caused some issues with dropping vxlan traffic in the ADC.