### PR TITLE
Update to Training topos: (#536)

### DIFF
--- a/topologies/training-level1/topo_build.yml
+++ b/topologies/training-level1/topo_build.yml
@@ -1,7 +1,7 @@
 host_cpu: 4
-cvp_cpu: 16
+cvp_cpu: 48
 cvp_nodes: 1
-veos_cpu: 1
+veos_cpu: 2
 nodes:
   - spine1:
       ip_addr: 192.168.0.11

--- a/topologies/training-level2/topo_build.yml
+++ b/topologies/training-level2/topo_build.yml
@@ -1,7 +1,7 @@
 host_cpu: 4
-cvp_cpu: 16
+cvp_cpu: 48
 cvp_nodes: 1
-veos_cpu: 1
+veos_cpu: 2
 nodes:
   - spine1:
       ip_addr: 192.168.0.11

--- a/topologies/training-level3-2/topo_build.yml
+++ b/topologies/training-level3-2/topo_build.yml
@@ -1,5 +1,5 @@
 host_cpu: 4
-cvp_cpu: 24
+cvp_cpu: 48
 cvp_nodes: 1
 veos_cpu: 2
 nodes:

--- a/topologies/training-level3-exam/topo_build.yml
+++ b/topologies/training-level3-exam/topo_build.yml
@@ -1,5 +1,5 @@
 host_cpu: 4
-cvp_cpu: 24
+cvp_cpu: 48
 cvp_nodes: 1
 veos_cpu: 2
 nodes:

--- a/topologies/training-level3/topo_build.yml
+++ b/topologies/training-level3/topo_build.yml
@@ -1,5 +1,5 @@
 host_cpu: 4
-cvp_cpu: 24
+cvp_cpu: 48
 cvp_nodes: 1
 veos_cpu: 2
 nodes:

--- a/topologies/training-level4/files/cvp/cvp_info.yaml
+++ b/topologies/training-level4/files/cvp/cvp_info.yaml
@@ -86,10 +86,6 @@ cvp_info:
       parent: Tenant
       nodes:
       - DCI
-    CVX:
-      parent: Tenant
-      nodes:
-      - CVX
   snapshots:
   configlets:
     containers:
@@ -156,8 +152,6 @@ cvp_info:
       - internet-BASE
       DCI:
       - DCI-BASE
-      CVX:
-      - CVX-BASE
       OOB-CORE:
       - OOB-CORE-BASE
       OOB-DC1:

--- a/topologies/training-level4/topo_build.yml
+++ b/topologies/training-level4/topo_build.yml
@@ -1,7 +1,7 @@
 host_cpu: 4
-cvp_cpu: 16
+cvp_cpu: 48
 cvp_nodes: 1
-veos_cpu: 1
+veos_cpu: 2
 nodes:
 # Spines DC1
   - spine1-DC1:
@@ -915,9 +915,9 @@ nodes:
           neighborPort: Ethernet2
           port: Ethernet2
 
-# CVX
-  - CVX:
-      ip_addr: 192.168.0.4
-      sys_mac: 00:1c:73:a4:c6:01
-      neighbors: []
+# # CVX
+#   - CVX:
+#       ip_addr: 192.168.0.4
+#       sys_mac: 00:1c:73:a4:c6:01
+#       neighbors: []
 additional_ssh_nodes:

--- a/topologies/training-level5/files/cvp/cvp_info.yaml
+++ b/topologies/training-level5/files/cvp/cvp_info.yaml
@@ -86,10 +86,6 @@ cvp_info:
       parent: Tenant
       nodes:
       - DCI
-    CVX:
-      parent: Tenant
-      nodes:
-      - CVX
   snapshots:
   configlets:
     containers:
@@ -156,8 +152,6 @@ cvp_info:
       - internet-BASE
       DCI:
       - DCI-BASE
-      CVX:
-      - CVX-BASE
       OOB-CORE:
       - OOB-CORE-BASE
       OOB-DC1:

--- a/topologies/training-level5/topo_build.yml
+++ b/topologies/training-level5/topo_build.yml
@@ -1,7 +1,7 @@
-host_cpu: 16
-cvp_cpu: 20
+host_cpu: 4
+cvp_cpu: 48
 cvp_nodes: 1
-veos_cpu: 1
+veos_cpu: 2
 nodes:
 # Spines DC1
   - spine1-DC1:
@@ -916,8 +916,8 @@ nodes:
           port: Ethernet2
 
 # CVX
-  - CVX:
-      ip_addr: 192.168.0.4
-      sys_mac: 00:1c:73:a4:c6:01
-      neighbors: []
+  # - CVX:
+  #     ip_addr: 192.168.0.4
+  #     sys_mac: 00:1c:73:a4:c6:01
+  #     neighbors: []
 additional_ssh_nodes:

--- a/topologies/training-level7/files/cvp/cvp_info.yaml
+++ b/topologies/training-level7/files/cvp/cvp_info.yaml
@@ -93,10 +93,6 @@ cvp_info:
       parent: Tenant
       nodes:
       - DCI
-    CVX:
-      parent: Tenant
-      nodes:
-      - CVX
   snapshots:
   configlets:
     containers:
@@ -171,8 +167,6 @@ cvp_info:
       - internet-SW1-ISP3-BASE
       DCI:
       - DCI-BASE
-      CVX:
-      - CVX-BASE
       OOB-CORE:
       - OOB-CORE-BASE
       OOB-DC1:

--- a/topologies/training-level7/topo_build.yml
+++ b/topologies/training-level7/topo_build.yml
@@ -1,7 +1,7 @@
-host_cpu: 20
-cvp_cpu: 20
+host_cpu: 4
+cvp_cpu: 48
 cvp_nodes: 1
-veos_cpu: 1
+veos_cpu: 2
 nodes:
 # Spines DC1
   - spine1-DC1:
@@ -1004,8 +1004,8 @@ nodes:
           port: Ethernet2
 
 # CVX
-  - CVX:
-      ip_addr: 192.168.0.4
-      sys_mac: 00:1c:73:a4:c6:01
-      neighbors: []
+  # - CVX:
+  #     ip_addr: 192.168.0.4
+  #     sys_mac: 00:1c:73:a4:c6:01
+  #     neighbors: []
 additional_ssh_nodes:


### PR DESCRIPTION
- Updated CVP CPU resources in training topologies
- Removed CVX from levels 4, 5 and 7