### PR TITLE
Readding the hosts file mount back into the coder container

### DIFF
--- a/nested-labvm/atd-docker/docker-compose.yml
+++ b/nested-labvm/atd-docker/docker-compose.yml
@@ -183,6 +183,7 @@ services:
       - /home/arista/arista-dir/apps/coder/coder.yaml:/home/coder/.config/code-server/config.yaml:rw
       - /home/arista/.ssh:/home/coder/.ssh:rw
       - /home/arista/GUI_Desktop/persist:/home/coder/project/persist:rw
+      - /home/arista/arista-dir/hosts:/etc/hosts:ro
       - /home/arista/arista-dir/apps/coder/labfiles:/home/coder/project/labfiles:rw
       - /home/arista/arista-dir/.ansible.cfg:/home/coder/.ansible.cfg:rw
       - /opt/sftp/uploads:/opt/sftp:ro


### PR DESCRIPTION
Reverting a portion of a change from #805. This adds back in the volume mount for the etc hosts file into the coder container.
