### PR TITLE
Cleanup pip installs and allow breaking system packages

### DIFF
--- a/nested-labvm/atd-docker/coder/Dockerfile
+++ b/nested-labvm/atd-docker/coder/Dockerfile
@@ -1,12 +1,16 @@
-FROM ghcr.io/coder/code-server:4.89.1-bookworm
+FROM ghcr.io/coder/code-server:4.90.1-bookworm
 
-# set the enviroment correctly first, including path
+# set the environment correctly first, including path
 USER coder
 ENV HOME=/home/coder
 ENV PATH=$PATH:/home/coder/.local/bin
 ENV AVD_VERSION="4.8.0"
 ENV CVP_VERSION="3.10.1"
 ENV ANTA_VERSION="0.14.0"
+# set args to cleanup installs
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_CACHE_DIR=1
+ARG PIP_BREAK_SYSTEM_PACKAGES=1
 
 RUN sudo apt update && \
     sudo apt install -y python3 git openssh-server vim nano less rsync man-db jq python3-pip wget zsh sshpass libvirt-clients && \
@@ -14,9 +18,8 @@ RUN sudo apt update && \
     sudo rm -rf /var/lib/apt/lists/* && \
     sudo apt-get clean
 
-RUN pip3 config set global.disable-pip-version-check true && \
-    pip3 install --user --no-cache-dir pyeapi jsonrpclib-pelix shyaml && \
-    pip3 install --user --no-cache-dir "ansible-core>=2.15.0,<2.17.0" --upgrade
+RUN pip3 install --user pyeapi jsonrpclib-pelix shyaml && \
+    pip3 install --user "ansible-core>=2.15.0,<2.17.0" --upgrade
 
 # Install arista.avd, community.general and ansible.posix ansible-galaxy collections, Use this for version control of AVD topologies
 RUN ansible-galaxy collection install arista.avd:==${AVD_VERSION} && \
@@ -25,7 +28,7 @@ RUN ansible-galaxy collection install arista.avd:==${AVD_VERSION} && \
     ansible-galaxy collection install ansible.posix --upgrade
 
 # Install Ansible-AVD collection requirements
-RUN pip3 install --user --no-cache-dir "pyavd[ansible]==${AVD_VERSION}" "anta==${ANTA_VERSION}" --upgrade
+RUN pip3 install --user "pyavd[ansible]==${AVD_VERSION}" "anta==${ANTA_VERSION}" --upgrade
 
 # Install Code extensions
 COPY src/vs-extensions.txt /home/coder/


### PR DESCRIPTION
Since we do not leverage a virtual environment on coder, we must set break system packages to true. Also setting pip flags to cleanup install commands. 

Also set coder version to latest at the time of this PR.