### PR TITLE
Use `secret_literal` instead of `secret_pattern` in allow list

### DIFF
--- a/.arista/secret_allowlist.yaml
+++ b/.arista/secret_allowlist.yaml
@@ -2,6 +2,6 @@
 
 version: v1.0
 allowed_secrets:
-- secret_pattern: "http://arista:arista@192.168.0.14"
+- secret_literal: "http://arista:arista@192.168.0.14"
   category: FALSE_POSITIVE
   reason: Used as example in documentation


### PR DESCRIPTION
The secret scanner has been updated to support `secret_literal` field in allow list. Use this instead since `secret_pattern` requires an regex pattern.