### PR TITLE
Update coder Dockerfile with pip3 global settings from automation workshops

### DIFF
--- a/nested-labvm/atd-docker/coder/Dockerfile
+++ b/nested-labvm/atd-docker/coder/Dockerfile
@@ -18,6 +18,10 @@ RUN sudo apt update && \
     sudo rm -rf /var/lib/apt/lists/* && \
     sudo apt-get clean
 
+# Set global vars to enable installation of different AVD/CVP collection versions for automation workshops
+RUN pip3 config set global.break-system-packages true && \
+    pip3 config set global.disable-pip-version-check true
+
 RUN pip3 install --user pyeapi jsonrpclib-pelix shyaml && \
     pip3 install --user "ansible-core>=2.15.0,<2.17.0" --upgrade
 

--- a/nested-labvm/atd-docker/docker-compose.yml
+++ b/nested-labvm/atd-docker/docker-compose.yml
@@ -172,7 +172,7 @@ services:
       - ./jenkins/src/groovy/users.groovy.override:/usr/share/jenkins/ref/init.groovy.d/users.groovy.override:rw
   coder:
     container_name: atd-coder
-    image: us.gcr.io/beta-atds/atddocker_coder:4.10.2-3.10.1-1.0.0
+    image: us.gcr.io/beta-atds/atddocker_coder:4.10.2-3.10.1-1.0.0-a
     restart: always
     user: $ArID:$ArGD
     command: /home/coder/project


### PR DESCRIPTION
Update coder/Dockerfile with pip3 changes for automation workshops:

# Set global vars to enable installation of different AVD/CVP collection versions for automation workshops
RUN pip3 config set global.break-system-packages true && \
         pip3 config set global.disable-pip-version-check true

Update Docker-Compose.yml
image: us.gcr.io/beta-atds/atddocker_coder:4.10.2-3.10.1-1.0.0-a