### PR TITLE
nautobot csrf fix for 2025.1

### DIFF
--- a/nested-labvm/atd-docker/nautobot/nautobot_config.py
+++ b/nested-labvm/atd-docker/nautobot/nautobot_config.py
@@ -19,7 +19,7 @@ ALLOWED_HOSTS = ['*']
 # ALLOWED_HOSTS = os.getenv("NAUTOBOT_ALLOWED_HOSTS", "").split(" ")
 
 # added to bypass CSRF check allowing nautobot to run properly
-CSRF_TRUSTED_ORIGINS = ["https://*.testdrive-dev.arista.com"]
+CSRF_TRUSTED_ORIGINS = ["https://*.testdrive-dev.arista.com","https://*.testdrive.arista.com"]
 
 # The django-redis cache is used to establish concurrent locks using Redis. The
 # django-rq settings will use the same instance/database by default.


### PR DESCRIPTION
Add https://*.testdrive.arista.com to CSRF trusted sites in nautobot-config.py. Fixes trust issue with ipam/nautobot in ATD verion 2025.1.